### PR TITLE
[SAMBAD-81] 실행 로직, 쿼리 로그 설정 및 서버 에러 모니터링 추가

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,5 @@
----
-title: '[SAMBAD-이슈번호] PR 제목'
----
+### 📍 [SAMBAD-이슈번호] PR 제목
+
 
 ## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
 - [ ] 기능 추가
@@ -10,7 +9,8 @@ title: '[SAMBAD-이슈번호] PR 제목'
 
 
 ## 📝 개요
-- (description)
+- 
+- 
   ```java
     
   ```
@@ -33,4 +33,4 @@ title: '[SAMBAD-이슈번호] PR 제목'
   - .
 
 ## 🔗 ISSUE 링크
-- resolved [#SAMBAD-이슈번호](노션이슈링크)
+- resolved [SAMBAD-이슈번호]()

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
+	implementation 'io.sentry:sentry-spring-boot-starter-jakarta:7.11.0'
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/org/depromeet/sambad/moyeo/common/config/P6spyConfig.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/common/config/P6spyConfig.java
@@ -1,0 +1,17 @@
+package org.depromeet.sambad.moyeo.common.config;
+
+import org.depromeet.sambad.moyeo.common.logging.P6spySqlLoggingFormatter;
+import org.springframework.context.annotation.Configuration;
+
+import com.p6spy.engine.spy.P6SpyOptions;
+
+import jakarta.annotation.PostConstruct;
+
+@Configuration
+public class P6spyConfig {
+
+	@PostConstruct
+	public void setLogMessageFormat() {
+		P6SpyOptions.getActiveInstance().setLogMessageFormat(P6spySqlLoggingFormatter.class.getName());
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moyeo/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/common/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import static org.depromeet.sambad.moyeo.file.presentation.exception.FileExcepti
 
 import java.util.Objects;
 
+import org.depromeet.sambad.moyeo.common.logging.LoggingUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
@@ -31,9 +32,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 	@ExceptionHandler(Exception.class)
 	protected ResponseEntity<ExceptionResponse> handleException(Exception exception) {
 		Sentry.captureException(exception);
-		if (exception.getCause() != null) {
-			log.error(exception.getCause().toString());
-		}
+		LoggingUtils.error(exception);
+
 		return ResponseEntity.internalServerError().body(ExceptionResponse.from(SERVER_ERROR));
 	}
 

--- a/src/main/java/org/depromeet/sambad/moyeo/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/common/exception/GlobalExceptionHandler.java
@@ -31,7 +31,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 	@ExceptionHandler(Exception.class)
 	protected ResponseEntity<ExceptionResponse> handleException(Exception exception) {
 		Sentry.captureException(exception);
-		log.error(exception.getCause().toString());
+		if (exception.getCause() != null) {
+			log.error(exception.getCause().toString());
+		}
 		return ResponseEntity.internalServerError().body(ExceptionResponse.from(SERVER_ERROR));
 	}
 

--- a/src/main/java/org/depromeet/sambad/moyeo/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/common/exception/GlobalExceptionHandler.java
@@ -15,6 +15,10 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+import io.sentry.Sentry;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
@@ -26,8 +30,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
 	@ExceptionHandler(Exception.class)
 	protected ResponseEntity<ExceptionResponse> handleException(Exception exception) {
-		return ResponseEntity.internalServerError()
-			.body(ExceptionResponse.from(SERVER_ERROR));
+		Sentry.captureException(exception);
+		log.error(exception.getCause().toString());
+		return ResponseEntity.internalServerError().body(ExceptionResponse.from(SERVER_ERROR));
 	}
 
 	@Override

--- a/src/main/java/org/depromeet/sambad/moyeo/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/common/exception/GlobalExceptionHandler.java
@@ -15,22 +15,17 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-import lombok.extern.slf4j.Slf4j;
-
-@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
 	@ExceptionHandler(BusinessException.class)
 	protected ResponseEntity<ExceptionResponse> handleBusinessException(BusinessException exception) {
-		log.info("Business Exception : ", exception.getCode());
 		ExceptionResponse response = ExceptionResponse.from(exception);
 		return ResponseEntity.status(response.status()).body(response);
 	}
 
 	@ExceptionHandler(Exception.class)
 	protected ResponseEntity<ExceptionResponse> handleException(Exception exception) {
-		log.warn("Unexpected Exception : ", exception);
 		return ResponseEntity.internalServerError()
 			.body(ExceptionResponse.from(SERVER_ERROR));
 	}
@@ -44,7 +39,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 			.getDefaultMessage()
 			.substring(index + 2);
 		ExceptionResponse response = ExceptionResponse.of(INVALID_INPUT.getStatus(), INVALID_INPUT.getCode(), message);
-		log.info("Business Exception : ", response.code());
 		return ResponseEntity.status(response.status()).body(response);
 	}
 
@@ -52,7 +46,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 	protected ResponseEntity<Object> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException ex,
 		HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 		ExceptionResponse response = ExceptionResponse.from(EXCEED_FILE_SIZE);
-		log.info("Business Exception : ", response.code());
 		return ResponseEntity.status(response.status()).body(response);
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moyeo/common/logging/ExecutionLoggingAdvice.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/common/logging/ExecutionLoggingAdvice.java
@@ -1,0 +1,98 @@
+package org.depromeet.sambad.moyeo.common.logging;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.depromeet.sambad.moyeo.common.exception.BusinessException;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Profile("local")
+@Slf4j
+@Aspect
+@Component
+public class ExecutionLoggingAdvice {
+
+	@Pointcut("execution(* org.depromeet.sambad.moyeo..*(..))")
+	private void allPointcut() {
+	}
+
+	@Pointcut("@annotation(org.depromeet.sambad.moyeo.common.logging.ExecutionTimer)")
+	private void executionTimer() {
+	}
+
+	@Around("executionTimer()")
+	public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+		StopWatch stopWatch = new StopWatch();
+
+		stopWatch.start();
+		Object proceed = joinPoint.proceed();
+		stopWatch.stop();
+
+		long totalTimeMillis = stopWatch.getTotalTimeMillis();
+
+		MethodSignature signature = (MethodSignature)joinPoint.getSignature();
+		String methodName = signature.getMethod().getName();
+
+		log.info("실행 메서드: {}, 실행시간 = {}ms", methodName, totalTimeMillis);
+		return proceed;
+	}
+
+	@Before("allPointcut()")
+	public void logBeforeExecution(JoinPoint joinPoint) {
+		MethodSignature signature = (MethodSignature)joinPoint.getSignature();
+		Class className = signature.getDeclaringType();
+		Method method = signature.getMethod();
+
+		List<String> arguments = Arrays.stream(joinPoint.getArgs())
+			.map(Object::toString)
+			.collect(Collectors.toList());
+		String parameterLog = IntStream.range(0, signature.getParameterNames().length)
+			.mapToObj(i -> signature.getParameterNames()[i] + " = " + arguments.get(i))
+			.collect(Collectors.joining(" | "));
+
+		log.info("[START] {} | {} {}", className.getSimpleName(), method.getName(), parameterLog);
+	}
+
+	@AfterReturning(value = "allPointcut()", returning = "result")
+	public void logAfterReturning(JoinPoint joinPoint, Object result) {
+		MethodSignature signature = (MethodSignature)joinPoint.getSignature();
+		Class className = signature.getDeclaringType();
+		Method method = signature.getMethod();
+
+		log.info("[SUCCESS] {} | {} | return = {}", className.getSimpleName(), method.getName(), result);
+	}
+
+	@AfterThrowing(value = "allPointcut()", throwing = "exception")
+	public void logAfterThrowing(JoinPoint joinPoint, BusinessException exception) {
+		MethodSignature signature = (MethodSignature)joinPoint.getSignature();
+
+		String className = signature.getDeclaringType().getSimpleName();
+		Method method = signature.getMethod();
+
+		List<String> arguments = Arrays.stream(joinPoint.getArgs())
+			.map(Object::toString)
+			.collect(Collectors.toList());
+		String parameterLog = IntStream.range(0, signature.getParameterNames().length)
+			.mapToObj(i -> signature.getParameterNames()[i] + " = " + arguments.get(i))
+			.collect(Collectors.joining(" | "));
+
+		log.error("[ERROR] {} | {} | throwing = {} | reqArgs : {}", className, method.getName(),
+			exception.getCode().getCode(), parameterLog);
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moyeo/common/logging/ExecutionLoggingAdvice.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/common/logging/ExecutionLoggingAdvice.java
@@ -1,10 +1,7 @@
 package org.depromeet.sambad.moyeo.common.logging;
 
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -59,14 +56,11 @@ public class ExecutionLoggingAdvice {
 		Class className = signature.getDeclaringType();
 		Method method = signature.getMethod();
 
-		List<String> arguments = Arrays.stream(joinPoint.getArgs())
-			.map(Object::toString)
-			.collect(Collectors.toList());
-		String parameterLog = IntStream.range(0, signature.getParameterNames().length)
-			.mapToObj(i -> signature.getParameterNames()[i] + " = " + arguments.get(i))
-			.collect(Collectors.joining(" | "));
+		String[] parameterNames = signature.getParameterNames();
+		List<String> arguments = LoggingUtils.getArguments(joinPoint);
+		String parameterMessage = LoggingUtils.getParameterMessage(parameterNames, arguments);
 
-		log.info("[START] {} | {} {}", className.getSimpleName(), method.getName(), parameterLog);
+		log.info("[START] {} | {} {}", className.getSimpleName(), method.getName(), parameterMessage);
 	}
 
 	@AfterReturning(value = "allPointcut()", returning = "result")
@@ -81,18 +75,14 @@ public class ExecutionLoggingAdvice {
 	@AfterThrowing(value = "allPointcut()", throwing = "exception")
 	public void logAfterThrowing(JoinPoint joinPoint, BusinessException exception) {
 		MethodSignature signature = (MethodSignature)joinPoint.getSignature();
-
 		String className = signature.getDeclaringType().getSimpleName();
 		Method method = signature.getMethod();
 
-		List<String> arguments = Arrays.stream(joinPoint.getArgs())
-			.map(Object::toString)
-			.collect(Collectors.toList());
-		String parameterLog = IntStream.range(0, signature.getParameterNames().length)
-			.mapToObj(i -> signature.getParameterNames()[i] + " = " + arguments.get(i))
-			.collect(Collectors.joining(" | "));
+		String[] parameterNames = signature.getParameterNames();
+		List<String> arguments = LoggingUtils.getArguments(joinPoint);
+		String parameterMessage = LoggingUtils.getParameterMessage(parameterNames, arguments);
 
 		log.error("[ERROR] {} | {} | throwing = {} | reqArgs : {}", className, method.getName(),
-			exception.getCode().getCode(), parameterLog);
+			exception.getCode().getCode(), parameterMessage);
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moyeo/common/logging/ExecutionTimer.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/common/logging/ExecutionTimer.java
@@ -1,0 +1,11 @@
+package org.depromeet.sambad.moyeo.common.logging;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExecutionTimer {
+}

--- a/src/main/java/org/depromeet/sambad/moyeo/common/logging/LoggingUtils.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/common/logging/LoggingUtils.java
@@ -1,5 +1,11 @@
 package org.depromeet.sambad.moyeo.common.logging;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.aspectj.lang.JoinPoint;
 import org.springframework.util.StringUtils;
 
 import lombok.extern.slf4j.Slf4j;
@@ -12,6 +18,18 @@ public class LoggingUtils {
 		StackTraceElement[] stackTraceElements = exception.getStackTrace();
 
 		log.error("[SERVER ERROR] {} {}", message, stackTraceElements[0]);
+	}
+
+	static List<String> getArguments(JoinPoint joinPoint) {
+		return Arrays.stream(joinPoint.getArgs())
+			.map(Object::toString)
+			.toList();
+	}
+
+	static String getParameterMessage(String[] parameterNames, List<String> arguments) {
+		return IntStream.range(0, parameterNames.length)
+			.mapToObj(i -> parameterNames[i] + " = " + arguments.get(i))
+			.collect(Collectors.joining(" | "));
 	}
 
 	private static String getExceptionMessage(String message) {

--- a/src/main/java/org/depromeet/sambad/moyeo/common/logging/LoggingUtils.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/common/logging/LoggingUtils.java
@@ -1,0 +1,23 @@
+package org.depromeet.sambad.moyeo.common.logging;
+
+import org.springframework.util.StringUtils;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class LoggingUtils {
+
+	public static void error(Exception exception) {
+		String message = getExceptionMessage(exception.getMessage());
+		StackTraceElement[] stackTraceElements = exception.getStackTrace();
+
+		log.error("[SERVER ERROR] {} {}", message, stackTraceElements[0]);
+	}
+
+	private static String getExceptionMessage(String message) {
+		if (StringUtils.hasText(message)) {
+			return message + "\n \t";
+		}
+		return "\n \t";
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moyeo/common/logging/P6spySqlLoggingFormatter.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/common/logging/P6spySqlLoggingFormatter.java
@@ -1,0 +1,43 @@
+package org.depromeet.sambad.moyeo.common.logging;
+
+import java.util.Locale;
+
+import org.hibernate.engine.jdbc.internal.FormatStyle;
+
+import com.p6spy.engine.logging.Category;
+import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
+
+public class P6spySqlLoggingFormatter implements MessageFormattingStrategy {
+
+	@Override
+	public String formatMessage(int connectionId, String now, long elapsed, String category, String prepared,
+		String sql, String url) {
+		sql = formatSql(category, sql);
+		return String.format(
+			"[SQL] %s | %d ms | connectionId = %d %s", category, elapsed, connectionId, formatSql(category, sql));
+	}
+
+	private String formatSql(String category, String sql) {
+		if (isEmpty(sql) || isNotStatement(category)) {
+			return sql;
+		}
+
+		String trimmedSql = sql.trim().toLowerCase(Locale.ROOT);
+		if (isDDL(trimmedSql)) {
+			return FormatStyle.DDL.getFormatter().format(sql);
+		}
+		return FormatStyle.BASIC.getFormatter().format(sql);
+	}
+
+	private boolean isEmpty(String sql) {
+		return sql == null || sql.trim().isEmpty();
+	}
+
+	private boolean isNotStatement(String category) {
+		return !Category.STATEMENT.getName().equals(category);
+	}
+
+	private boolean isDDL(String sql) {
+		return sql.startsWith("create") || sql.startsWith("alter");
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moyeo/common/logging/ServerErrorAlertAdvice.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/common/logging/ServerErrorAlertAdvice.java
@@ -1,0 +1,62 @@
+package org.depromeet.sambad.moyeo.common.logging;
+
+import static org.springframework.http.HttpStatus.*;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.depromeet.sambad.moyeo.common.exception.BusinessException;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import io.sentry.Sentry;
+import lombok.extern.slf4j.Slf4j;
+
+@Profile({"dev", "prod"})
+@Slf4j
+@Aspect
+@Component
+public class ServerErrorAlertAdvice {
+
+	@Pointcut("execution(* org.depromeet.sambad.moyeo..*(..))")
+	private void allPointcut() {
+	}
+
+	@AfterThrowing(value = "allPointcut()", throwing = "exception")
+	public void logAndAlertAfterThrowing(JoinPoint joinPoint, Throwable exception) {
+		if (!(exception instanceof BusinessException)) {
+			return;
+		}
+
+		BusinessException businessException = (BusinessException)exception;
+		if (!businessException.getCode().getStatus().equals(INTERNAL_SERVER_ERROR)) {
+			return;
+		}
+
+		MethodSignature signature = (MethodSignature)joinPoint.getSignature();
+
+		String className = signature.getDeclaringType().getSimpleName();
+		Method method = signature.getMethod();
+
+		List<String> arguments = Arrays.stream(joinPoint.getArgs())
+			.map(Object::toString)
+			.collect(Collectors.toList());
+		String parameterLog = IntStream.range(0, signature.getParameterNames().length)
+			.mapToObj(i -> signature.getParameterNames()[i] + " = " + arguments.get(i))
+			.collect(Collectors.joining(" | "));
+
+		Sentry.captureException(exception);
+		log.error("[SERVER ERROR] {} | {} | throwing = {} | reqArgs : {}", className, method.getName(),
+			businessException.getCode().getCode(), parameterLog);
+		log.error("[SERVER ERROR DESCRIPTION] code : {} | message : {}", businessException.getCode(),
+			businessException.getMessage());
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moyeo/common/logging/ServerErrorAlertAdvice.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/common/logging/ServerErrorAlertAdvice.java
@@ -58,5 +58,6 @@ public class ServerErrorAlertAdvice {
 			businessException.getCode().getCode(), parameterLog);
 		log.error("[SERVER ERROR DESCRIPTION] code : {} | message : {}", businessException.getCode(),
 			businessException.getMessage());
+		log.error(exception.getCause().toString());
 	}
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,4 @@
+sentry:
+  dsn: ${SENTRY_DSN}
+  environment: dev
+  release: "moring-dev@1.0.0"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,3 +2,11 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+
+sentry:
+  enabled: false
+
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: true

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -5,8 +5,3 @@ spring:
 
 sentry:
   enabled: false
-
-decorator:
-  datasource:
-    p6spy:
-      enable-logging: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -3,3 +3,8 @@ springdoc:
     enabled: false
   swagger-ui:
     enabled: false
+
+sentry:
+  dsn: ${SENTRY_DSN}
+  environment: prod
+  release: "moring-prod@1.0.0"

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -8,3 +8,8 @@ sentry:
   dsn: ${SENTRY_DSN}
   environment: prod
   release: "moring-prod@1.0.0"
+
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+      default_batch_fetch_size: 1000
+      jdbc:
+        time_zone: Asia/Seoul
   data:
     redis:
       host: ${REDIS_HOST:localhost}
@@ -29,3 +32,14 @@ springdoc:
   swagger-ui:
     operations-sorter: alpha
     tags-sorter: alpha
+
+sentry:
+  dsn: ${SENTRY_DSN}
+  exception-resolver-order: -2147483647
+  max-request-body-size: always
+  tracesSampleRate: 1.0
+
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,4 +42,4 @@ sentry:
 decorator:
   datasource:
     p6spy:
-      enable-logging: false
+      enable-logging: true


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## 📝 개요
- **local 환경**에서는 모든 실행 로직과 쿼리 로그를 남기도록 하였습니다. jpa.properties.hibernate.show_sql 혹은 format_sql 대신 p6spy 라이브러리를 사용해서 값이 찍히는 로그를 남기도록 했어요.
- **dev 및 prod 환경**에서는 예상치 못한 서버 에러가 발생했을 경우에만, 관련 stack trace 로그를 남기고, 에러 캡쳐링하여 센트리를 통해 저희 공용 구글 계정과 개인 계정 메일 발송하도록 설정하였습니다. 노션에 적힌 개인 메일로 초대해두었으니, 필요 시 수락하시면 됩니다!


아래는 로컬 환경에서 콘솔 입니다. dev 및 prod 환경에서는 아래 로그 대신, 서버 에러 발생 시에만 관련 로그가 찍히게 됩니다.

<img width="1554" alt="스크린샷 2024-07-12 오후 6 57 28" src="https://github.com/user-attachments/assets/de984670-99fd-4c82-b26f-681444791b73">
<img width="1771" alt="스크린샷 2024-07-12 오후 6 57 40" src="https://github.com/user-attachments/assets/4bbb7295-f196-4703-aefe-b39cbf8e229e">


## 🔗 ISSUE 링크
- resolved [SAMBAD-81](https://www.notion.so/depromeet/ea2892a29b1d448c8ac6bd9f56b65a48?pvs=4)