### PR TITLE
[SAMBAD-95] NCP Object Storage를 사용한 파일 업로드 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'com.amazonaws:aws-java-sdk-s3:1.11.238'
+	implementation 'javax.xml.bind:jaxb-api:2.3.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/depromeet/sambad/moyeo/common/config/ObjectStorageConfig.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/common/config/ObjectStorageConfig.java
@@ -1,0 +1,38 @@
+package org.depromeet.sambad.moyeo.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+public class ObjectStorageConfig {
+
+	@Value("${cloud.ncp.object-storage.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${cloud.ncp.object-storage.credentials.secret-key}")
+	private String secretKey;
+
+	@Value("${cloud.ncp.region.static}")
+	private String region;
+
+	@Value("${cloud.ncp.object-storage.endpoint}")
+	private String endpoint;
+
+	@Bean
+	public AmazonS3 amazonS3() {
+		BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+		return AmazonS3ClientBuilder
+			.standard()
+			.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, region))
+			.withCredentials(new AWSStaticCredentialsProvider(credentials))
+			.build();
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moyeo/common/config/SecurityConfig.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/common/config/SecurityConfig.java
@@ -14,6 +14,7 @@ public class SecurityConfig {
 
 	private static final String[] PERMIT_ALL_PATTERNS = {
 		"/swagger-ui/**",
+		"/v3/api-docs/**",
 		"/actuator/health"
 	};
 

--- a/src/main/java/org/depromeet/sambad/moyeo/common/config/SecurityConfig.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/common/config/SecurityConfig.java
@@ -15,7 +15,8 @@ public class SecurityConfig {
 	private static final String[] PERMIT_ALL_PATTERNS = {
 		"/swagger-ui/**",
 		"/v3/api-docs/**",
-		"/actuator/health"
+		"/actuator/health",
+		"/api/v1/object-storage/**"
 	};
 
 	@Bean

--- a/src/main/java/org/depromeet/sambad/moyeo/file/application/FileService.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/file/application/FileService.java
@@ -1,18 +1,34 @@
 package org.depromeet.sambad.moyeo.file.application;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.depromeet.sambad.moyeo.file.domain.FileEntity;
 import org.depromeet.sambad.moyeo.file.domain.FileRepository;
+import org.depromeet.sambad.moyeo.file.infrastructure.ObjectStorageFileUploader;
+import org.depromeet.sambad.moyeo.file.presentation.response.FileUrlResponse;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.Objects;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
+@Slf4j
 public class FileService {
 
 	private final FileUploader fileUploader;
 	private final FileRepository fileRepository;
+	private final ObjectStorageFileUploader objectStorageFileUploader;
+
+	public FileUrlResponse upload(String logicalName, MultipartFile multipartFile) throws IOException {
+		String url = objectStorageFileUploader.upload(multipartFile, logicalName);
+		return FileUrlResponse.of(url);
+	}
 
 	public FileEntity uploadAndSave(String fileUrl) {
 		// TODO: add url validation
@@ -24,4 +40,5 @@ public class FileService {
 			throw new RuntimeException("Failed to upload file", e);
 		}
 	}
+
 }

--- a/src/main/java/org/depromeet/sambad/moyeo/file/domain/FileRepository.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/file/domain/FileRepository.java
@@ -3,4 +3,8 @@ package org.depromeet.sambad.moyeo.file.domain;
 public interface FileRepository {
 
 	FileEntity save(FileEntity fileEntity);
+
+	boolean existsByLogicalName(String logicalName);
+
+	void deleteByLogicalName(String logicalName);
 }

--- a/src/main/java/org/depromeet/sambad/moyeo/file/infrastructure/FileJpaRepository.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/file/infrastructure/FileJpaRepository.java
@@ -4,4 +4,7 @@ import org.depromeet.sambad.moyeo.file.domain.FileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FileJpaRepository extends JpaRepository<FileEntity, Long> {
+	boolean existsByLogicalName(String logicalName);
+
+	void deleteByLogicalName(String logicalName);
 }

--- a/src/main/java/org/depromeet/sambad/moyeo/file/infrastructure/FileRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/file/infrastructure/FileRepositoryImpl.java
@@ -1,9 +1,10 @@
 package org.depromeet.sambad.moyeo.file.infrastructure;
 
-import lombok.RequiredArgsConstructor;
 import org.depromeet.sambad.moyeo.file.domain.FileEntity;
 import org.depromeet.sambad.moyeo.file.domain.FileRepository;
 import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Repository
@@ -13,5 +14,15 @@ public class FileRepositoryImpl implements FileRepository {
 	@Override
 	public FileEntity save(FileEntity fileEntity) {
 		return fileJpaRepository.save(fileEntity);
+	}
+
+	@Override
+	public boolean existsByLogicalName(String logicalName) {
+		return fileJpaRepository.existsByLogicalName(logicalName);
+	}
+
+	@Override
+	public void deleteByLogicalName(String logicalName) {
+		fileJpaRepository.deleteByLogicalName(logicalName);
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moyeo/file/infrastructure/ObjectStorageFileUploader.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/file/infrastructure/ObjectStorageFileUploader.java
@@ -1,0 +1,89 @@
+package org.depromeet.sambad.moyeo.file.infrastructure;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.depromeet.sambad.moyeo.file.application.FileUploader;
+import org.depromeet.sambad.moyeo.file.presentation.exception.ObjectStorageServerException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ObjectStorageFileUploader implements FileUploader {
+
+	private final AmazonS3 amazonS3;
+
+	@Value("${cloud.ncp.object-storage.credentials.bucket}")
+	private String bucketName;
+
+	@Override
+	public String upload(MultipartFile multipartFile, String logicalName) throws IOException {
+		File uploadFile = convert(multipartFile)
+			.orElseThrow(() -> new IllegalArgumentException("MultipartFile -> File convert failed."));
+		amazonS3.putObject(
+			new PutObjectRequest(bucketName, logicalName, uploadFile)
+				.withCannedAcl(CannedAccessControlList.PublicRead)	// PublicRead 권한으로 업로드 됨
+		);
+		removeNewFile(uploadFile);
+		return amazonS3.getUrl(bucketName, logicalName).toString();
+	}
+
+	@Override
+	public String upload(String fileUrl) throws ObjectStorageServerException {
+		try {
+			String fileName = getFileNameFromUrl(fileUrl);
+			amazonS3.putObject(bucketName, fileName, fileUrl);
+			return amazonS3.getUrl(bucketName, fileName).toString();
+		} catch (ObjectStorageServerException e ) {
+			throw new ObjectStorageServerException();
+		}
+	}
+
+	@Override
+	public String getFileExtension(String fileName) {
+		return FileUploader.super.getFileExtension(fileName);
+	}
+
+	@Override
+	public String generateUniqueFileName(String fileExtension) {
+		return FileUploader.super.generateUniqueFileName(fileExtension);
+	}
+
+	@Override
+	public String getFileNameFromUrl(String fileUrl) {
+		return FileUploader.super.getFileNameFromUrl(fileUrl);
+	}
+
+	private Optional<File> convert(MultipartFile file) throws IOException {
+		log.info(file.getOriginalFilename());
+		File convertFile = new File(Objects.requireNonNull(file.getOriginalFilename()));
+		if(convertFile.createNewFile()) {
+			try (FileOutputStream fos = new FileOutputStream(convertFile)) {
+				fos.write(file.getBytes());
+			}
+			return Optional.of(convertFile);
+		}
+		return Optional.empty();
+	}
+
+	private void removeNewFile(File targetFile) {
+		if(targetFile.delete()) {
+			log.info("File deleted.");
+		}else {
+			log.info("File could not deleted");
+		}
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moyeo/file/presentation/ObjectStorageController.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/file/presentation/ObjectStorageController.java
@@ -1,28 +1,47 @@
 package org.depromeet.sambad.moyeo.file.presentation;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import org.depromeet.sambad.moyeo.file.application.FileService;
 import org.depromeet.sambad.moyeo.file.presentation.response.FileUrlResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/object-storage")
+@Tag(name = "ObjectStorage", description = "파일 저장소")
 public class ObjectStorageController {
 
 	private final FileService fileService;
 
 	@PostMapping(path = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	public ResponseEntity<FileUrlResponse> uploadPetImage(
+	@Operation(
+		summary = "[U] 파일 업로드",
+		description = "파일을 업로드합니다.",
+		parameters = {
+			@Parameter(name = "fileName", description = "파일 이름", required = true),
+			@Parameter(name = "file", description = "파일", required = true)
+		}
+	)
+	public ResponseEntity<FileUrlResponse> uploadFile(
 		@RequestPart(value = "fileName") String fileName,
 		@RequestPart(value = "file", required = false) MultipartFile multipartFile
 	) throws IOException {
@@ -30,6 +49,39 @@ public class ObjectStorageController {
 		return ResponseEntity.ok(response);
 	}
 
+	@GetMapping(path = "/download/{fileName}")
+	@Operation(
+		summary = "[U] 파일 다운로드",
+		description = "파일을 다운로드합니다.",
+		parameters = {
+			@Parameter(name = "fileName", description = "파일 이름", required = true)
+		}
+	)
+	public ResponseEntity<byte[]> downloadFile(
+		@PathVariable String fileName
+	) {
+		byte[] file = fileService.download(fileName);
+		String downloadedFileName = URLEncoder.encode(fileName, StandardCharsets.UTF_8);
+		HttpHeaders httpHeaders = new HttpHeaders();
+		httpHeaders.setContentType(MediaType.IMAGE_JPEG);
+		httpHeaders.setContentLength(file.length);
+		httpHeaders.setContentDispositionFormData("attachment", downloadedFileName);
+		return new ResponseEntity<byte[]>(file, httpHeaders, HttpStatus.OK);
+	}
 
+	@DeleteMapping(path = "/delete", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@Operation(
+		summary = "[U] 파일 삭제",
+		description = "파일을 삭제합니다.",
+		parameters = {
+			@Parameter(name = "fileName", description = "파일 이름", required = true)
+		}
+	)
+	public ResponseEntity<Void> deleteFile(
+		@RequestPart(value = "fileName") String fileName
+	) {
+		fileService.delete(fileName);
+		return ResponseEntity.noContent().build();
+	}
 
 }

--- a/src/main/java/org/depromeet/sambad/moyeo/file/presentation/ObjectStorageController.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/file/presentation/ObjectStorageController.java
@@ -1,0 +1,35 @@
+package org.depromeet.sambad.moyeo.file.presentation;
+
+import java.io.IOException;
+
+import org.depromeet.sambad.moyeo.file.application.FileService;
+import org.depromeet.sambad.moyeo.file.presentation.response.FileUrlResponse;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/object-storage")
+public class ObjectStorageController {
+
+	private final FileService fileService;
+
+	@PostMapping(path = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public ResponseEntity<FileUrlResponse> uploadPetImage(
+		@RequestPart(value = "fileName") String fileName,
+		@RequestPart(value = "file", required = false) MultipartFile multipartFile
+	) throws IOException {
+		FileUrlResponse response = fileService.upload(fileName, multipartFile);
+		return ResponseEntity.ok(response);
+	}
+
+
+
+}

--- a/src/main/java/org/depromeet/sambad/moyeo/file/presentation/exception/FileDeleteErrorException.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/file/presentation/exception/FileDeleteErrorException.java
@@ -1,0 +1,11 @@
+package org.depromeet.sambad.moyeo.file.presentation.exception;
+
+import static org.depromeet.sambad.moyeo.file.presentation.exception.FileExceptionCode.FILE_DELETE_ERROR;
+
+import org.depromeet.sambad.moyeo.common.exception.BusinessException;
+
+public class FileDeleteErrorException extends BusinessException {
+	public FileDeleteErrorException() {
+		super(FILE_DELETE_ERROR);
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moyeo/file/presentation/exception/FileExceptionCode.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/file/presentation/exception/FileExceptionCode.java
@@ -18,7 +18,10 @@ public enum FileExceptionCode implements ExceptionCode {
 
 	UNSUPPORTED_FILE_TYPE(UNSUPPORTED_MEDIA_TYPE, "파일 형식은 '.jpg', '.jpeg', '.png' 만 가능합니다."),
 
-	OBJECTSTORAGE_SERVER_ERROR(INTERNAL_SERVER_ERROR, "파일 처리 중 서버 에러가 발생했습니다.");
+	OBJECTSTORAGE_SERVER_ERROR(INTERNAL_SERVER_ERROR, "파일 처리 중 서버 에러가 발생했습니다."),
+
+	FILE_UPLOAD_ERROR(INTERNAL_SERVER_ERROR, "파일 업로드 중 에러가 발생했습니다."),
+	FILE_DELETE_ERROR(INTERNAL_SERVER_ERROR, "파일 삭제 중 에러가 발생했습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/org/depromeet/sambad/moyeo/file/presentation/exception/FileUploadErrorException.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/file/presentation/exception/FileUploadErrorException.java
@@ -1,0 +1,11 @@
+package org.depromeet.sambad.moyeo.file.presentation.exception;
+
+import static org.depromeet.sambad.moyeo.file.presentation.exception.FileExceptionCode.FILE_UPLOAD_ERROR;
+
+import org.depromeet.sambad.moyeo.common.exception.BusinessException;
+
+public class FileUploadErrorException extends BusinessException {
+	public FileUploadErrorException () {
+		super(FILE_UPLOAD_ERROR);
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moyeo/file/presentation/response/FileResponse.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/file/presentation/response/FileResponse.java
@@ -1,0 +1,17 @@
+package org.depromeet.sambad.moyeo.file.presentation.response;
+
+import java.time.LocalDateTime;
+
+import org.depromeet.sambad.moyeo.file.domain.FileEntity;
+
+public record FileResponse(
+	String url,
+	String logicalName,
+	LocalDateTime createAt,
+	LocalDateTime updateAt
+
+) {
+	public static FileResponse of(String url, FileEntity fileEntity) {
+		return new FileResponse(url, fileEntity.getLogicalName(), fileEntity.getCreateAt(), fileEntity.getUpdateAt());
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moyeo/file/presentation/response/FileUrlResponse.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/file/presentation/response/FileUrlResponse.java
@@ -1,0 +1,9 @@
+package org.depromeet.sambad.moyeo.file.presentation.response;
+
+public record FileUrlResponse(
+	String url
+) {
+	public static FileUrlResponse of(String url) {
+		return new FileUrlResponse(url);
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,3 +43,17 @@ decorator:
   datasource:
     p6spy:
       enable-logging: true
+
+cloud:
+  ncp:
+    object-storage:
+      endpoint: "https://kr.object.ncloudstorage.com"
+      credentials:
+        access-key: ${NCP_ACCESS_KEY}
+        secret-key: ${NCP_SECRET_KEY}
+        bucket: ${NCP_BUCKET_NAME}
+    region:
+      static: "ap-southeast-2"
+      auto: false
+    stack:
+      auto: false


### PR DESCRIPTION
### 📍 [SAMBAD-95] NCP Object Storage를 사용한 파일 업로드 기능


## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- NCP Object Storage를 사용하여 파일 업로드, 다운로드, 조회 기능을 구현합니다.
- 파일 정보를 DB에 저장합니다.
```java
@Override
	public String upload(MultipartFile multipartFile, String logicalName) throws IOException {
		try {
			File uploadFile = convert(multipartFile)
				.orElseThrow(() -> new IllegalArgumentException("MultipartFile -> File convert failed."));
			amazonS3.putObject(
				new PutObjectRequest(bucketName, logicalName, uploadFile)
					.withCannedAcl(CannedAccessControlList.PublicRead)
			);
			removeNewFile(uploadFile);
		} catch (FileUploadErrorException e) {
			throw new FileUploadErrorException();
		}
		return amazonS3.getUrl(bucketName, logicalName).toString();
	}
```

## ✏️ 변경 사항
### [커밋타이틀-1](커밋링크)
  
  - description-1
  - description-2

### [커밋타이틀-2](커밋링크)

- description-1
- description-2


## 💡 코드 리뷰 시 참고 사항
  - Service, Repository 등 각 계층이 올바른 패키지 구조로 이루어져 있는지 확인 부탁드립니다.

## 🔗 ISSUE 링크
- resolved [SAMBAD-이슈번호]()