### PR TITLE
[SAMBAD-103] AOP에서 JwtTokenFilter 프록시 객체 생성 버그 수정

### DIFF
--- a/src/main/java/org/depromeet/sambad/moyeo/auth/infrastructure/TokenProperties.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/auth/infrastructure/TokenProperties.java
@@ -1,12 +1,13 @@
 package org.depromeet.sambad.moyeo.auth.infrastructure;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "jwt")
 public record TokenProperties(
-		@NotNull String secretKey,
-		@Min(0) long expirationTimeMs
+	@NotNull String secretKey,
+	@Min(0) long expirationTimeMs
 ) {
 }

--- a/src/main/java/org/depromeet/sambad/moyeo/common/logging/ExecutionLoggingAdvice.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/common/logging/ExecutionLoggingAdvice.java
@@ -25,7 +25,9 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class ExecutionLoggingAdvice {
 
-	@Pointcut("execution(* org.depromeet.sambad.moyeo..*(..))")
+	@Pointcut(
+		"within(org.depromeet.sambad.moyeo..*) && " + "!@within(org.depromeet.sambad.moyeo.auth.presentation.*Filter)"
+	)
 	private void allPointcut() {
 	}
 

--- a/src/main/java/org/depromeet/sambad/moyeo/common/logging/ServerErrorAlertAdvice.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/common/logging/ServerErrorAlertAdvice.java
@@ -23,7 +23,9 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class ServerErrorAlertAdvice {
 
-	@Pointcut("execution(* org.depromeet.sambad.moyeo..*(..))")
+	@Pointcut(
+		"within(org.depromeet.sambad.moyeo..*) && " + "!@within(org.depromeet.sambad.moyeo.auth.presentation.*Filter)"
+	)
 	private void allPointcut() {
 	}
 

--- a/src/main/java/org/depromeet/sambad/moyeo/meetingQuestion/domain/MeetingQuestion.java
+++ b/src/main/java/org/depromeet/sambad/moyeo/meetingQuestion/domain/MeetingQuestion.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.depromeet.sambad.moyeo.meeting.domain.Meeting;
 import org.depromeet.sambad.moyeo.meetingAnswer.domain.MeetingMemberAnswer;
 import org.depromeet.sambad.moyeo.question.domain.Question;
 
@@ -30,14 +29,14 @@ public class MeetingQuestion {
 	private Long id;
 
 	// FIXME: Meeting에서 mappedBy = "meeting" 지정
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "meeting_id")
-	private Meeting meeting;
+	// @ManyToOne(fetch = FetchType.LAZY)
+	// @JoinColumn(name = "meeting_id")
+	// private Meeting meeting;
 
 	// FIXME: MeetingMember에서 mappedBy="registeredMember" 지정
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "meeting_member_id")
-	private MeetingMember registeredMember;
+	// @ManyToOne(fetch = FetchType.LAZY)
+	// @JoinColumn(name = "meeting_member_id")
+	// private MeetingMember registeredMember;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "question_id")


### PR DESCRIPTION
### 📍 [SAMBAD-이슈번호] PR 제목


## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정


## 📝 개요
- oAuth PR을 합친 후로, 기존의 AOP를 적용한 로깅 Advice에서 AopConfigException과 아래 버그가 발생

```
Unable to proxy interface-implementing method [public final void org.springframework.web.filter.OncePerRequestFilter.doFilter(jakarta.servlet.ServletRequest,jakarta.servlet.ServletResponse,jakarta.servlet.FilterChain) throws jakarta.servlet.ServletExcep..
```

```
Cannot subclass final class {..}Properties
```

- 처음에는, [참고링크](https://stackoverflow.com/questions/69221447/spring-is-trying-to-subclass-a-record-component-when-aop-is-present) 를 보고, record 클래스인 Properties에 대해 타겟 제거를 해주었지만 여전히 첫번째 버그 발생
- Filter 구현체인 JwtTokenFilter 클래스를 proxy 객체로 만드는 과정에서 첫 번째 버그가 발생했다고 추측하여, 우선 해당 클래스를 타겟 제거하는 방식으로 눈 앞의 문제는 해결...

- 추가로, 아직 반영하지 않은 모임원, 모임 관련 도메인으로 매핑되지 못한 필드들은 실행에 문제가 있어 반영될 때까지 주석처리 해두겠습니다.

## 🔗 ISSUE 링크
- resolved [SAMBAD-103](https://www.notion.so/depromeet/AOP-JwtTokenFilter-d3ce42d924b245b58a3091214805b640?pvs=4)