### PR TITLE
[SAMBAD-117] 모임 및 모임원 관련 Entity 추가

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/domain/MeetingMemberAnswer.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/domain/MeetingMemberAnswer.java
@@ -1,5 +1,6 @@
 package org.depromeet.sambad.moring.meeting.answer.domain;
 
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
 import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
 
 import jakarta.persistence.Entity;
@@ -25,4 +26,8 @@ public class MeetingMemberAnswer {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "meeting_question_id")
 	private MeetingQuestion meetingQuestion;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "meeting_member_id")
+	private MeetingMember meetingMember;
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/domain/Meeting.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/domain/Meeting.java
@@ -1,0 +1,36 @@
+package org.depromeet.sambad.moring.meeting.meeting.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.depromeet.sambad.moring.common.domain.BaseTimeEntity;
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
+import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Meeting extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "meeting_id")
+    private Long id;
+
+    private String name;
+
+    private String code;
+
+    @OneToMany(mappedBy = "meeting")
+    private List<MeetingMember> meetingMembers = new ArrayList<>();
+
+    @OneToMany(mappedBy = "meeting")
+    private List<TypesPerMeeting> typesPerMeetings = new ArrayList<>();
+
+    @OneToMany(mappedBy = "meeting")
+    private List<MeetingQuestion> meetingQuestions = new ArrayList<>();
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/domain/MeetingType.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/domain/MeetingType.java
@@ -1,0 +1,20 @@
+package org.depromeet.sambad.moring.meeting.meeting.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.depromeet.sambad.moring.common.domain.BaseTimeEntity;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MeetingType extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "meeting_type_id")
+    private Long id;
+
+    private String content;
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/domain/TypesPerMeeting.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/domain/TypesPerMeeting.java
@@ -1,0 +1,26 @@
+package org.depromeet.sambad.moring.meeting.meeting.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.depromeet.sambad.moring.common.domain.BaseTimeEntity;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TypesPerMeeting extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "types_per_meeting_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_id")
+    private Meeting meeting;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_type_id")
+    private MeetingType meetingType;
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberRepository.java
@@ -1,0 +1,11 @@
+package org.depromeet.sambad.moring.meeting.member.application;
+
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
+
+import java.util.Optional;
+
+public interface MeetingMemberRepository {
+    Optional<MeetingMember> findByUserId(Long userId);
+
+    Optional<MeetingMember> findById(Long meetingMemberId);
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberService.java
@@ -1,0 +1,22 @@
+package org.depromeet.sambad.moring.meeting.member.application;
+
+import lombok.RequiredArgsConstructor;
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class MeetingMemberService {
+
+    private final MeetingMemberRepository meetingMemberRepository;
+
+    public MeetingMember getByUserId(Long userId) {
+        return meetingMemberRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("MeetingMember not found. userId: " + userId));
+    }
+
+    public MeetingMember getById(Long meetingMemberId) {
+        return meetingMemberRepository.findById(meetingMemberId)
+                .orElseThrow(() -> new IllegalArgumentException("MeetingMember not found. meetingMemberId: " + meetingMemberId));
+    }
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/Hobby.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/Hobby.java
@@ -1,0 +1,19 @@
+package org.depromeet.sambad.moring.meeting.member.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Hobby {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "hobby_id")
+    private Long id;
+
+    private String content;
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMember.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMember.java
@@ -1,0 +1,48 @@
+package org.depromeet.sambad.moring.meeting.member.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.depromeet.sambad.moring.common.domain.BaseTimeEntity;
+import org.depromeet.sambad.moring.file.domain.FileEntity;
+import org.depromeet.sambad.moring.meeting.meeting.domain.Meeting;
+import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
+import org.depromeet.sambad.moring.user.domain.User;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MeetingMember extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "meeting_member_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_id")
+    private Meeting meeting;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profile_image_id")
+    private FileEntity profileImage;
+
+    @OneToMany(mappedBy = "targetMember", fetch = FetchType.LAZY)
+    private List<MeetingQuestion> meetingQuestions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "meetingMember", fetch = FetchType.LAZY)
+    private List<MeetingMemberHobby> meetingMemberHobbies = new ArrayList<>();
+
+    public boolean isOtherMeeting(MeetingMember targetMember) {
+        return !Objects.equals(this.meeting, targetMember.getMeeting());
+    }
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMemberHobby.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMemberHobby.java
@@ -1,0 +1,25 @@
+package org.depromeet.sambad.moring.meeting.member.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MeetingMemberHobby {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "meeting_member_hobby_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_member_id")
+    private MeetingMember meetingMember;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hobby_id")
+    private Hobby hobby;
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/infrastructure/MeetingMemberJpaRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/infrastructure/MeetingMemberJpaRepository.java
@@ -1,0 +1,11 @@
+package org.depromeet.sambad.moring.meeting.member.infrastructure;
+
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MeetingMemberJpaRepository extends JpaRepository<MeetingMember, Long> {
+
+    Optional<MeetingMember> findByUserId(Long userId);
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/infrastructure/MeetingMemberRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/infrastructure/MeetingMemberRepositoryImpl.java
@@ -1,0 +1,25 @@
+package org.depromeet.sambad.moring.meeting.member.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.depromeet.sambad.moring.meeting.member.application.MeetingMemberRepository;
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Repository
+public class MeetingMemberRepositoryImpl implements MeetingMemberRepository {
+
+    private final MeetingMemberJpaRepository meetingMemberJpaRepository;
+
+    @Override
+    public Optional<MeetingMember> findByUserId(Long userId) {
+        return meetingMemberJpaRepository.findByUserId(userId);
+    }
+
+    @Override
+    public Optional<MeetingMember> findById(Long meetingMemberId) {
+        return meetingMemberJpaRepository.findById(meetingMemberId);
+    }
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionService.java
@@ -4,6 +4,9 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import org.depromeet.sambad.moring.meeting.meeting.domain.Meeting;
+import org.depromeet.sambad.moring.meeting.member.application.MeetingMemberService;
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
 import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
 import org.depromeet.sambad.moring.meeting.question.presentation.exception.DuplicateMeetingQuestionException;
 import org.depromeet.sambad.moring.meeting.question.presentation.exception.InvalidMeetingMemberTargetException;
@@ -36,7 +39,7 @@ public class MeetingQuestionService {
 		MeetingMember targetMember = meetingMemberService.getById(request.meetingMemberId());
 		validateTargetMember(loginMember, targetMember);
 
-		Meeting meeting = meetingMember.getMeeting();
+		Meeting meeting = targetMember.getMeeting();
 		Question question = questionService.getById(request.questionId());
 		validateDuplicateMeetingQuestion(meeting, question);
 

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/domain/MeetingQuestion.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/domain/MeetingQuestion.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 import org.depromeet.sambad.moring.common.domain.BaseTimeEntity;
 import org.depromeet.sambad.moring.meeting.answer.domain.MeetingMemberAnswer;
+import org.depromeet.sambad.moring.meeting.meeting.domain.Meeting;
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
 import org.depromeet.sambad.moring.question.domain.Question;
 
 import jakarta.persistence.Entity;

--- a/src/main/java/org/depromeet/sambad/moring/question/infrastructure/QuestionRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moring/question/infrastructure/QuestionRepositoryImpl.java
@@ -1,13 +1,21 @@
 package org.depromeet.sambad.moring.question.infrastructure;
 
 import org.depromeet.sambad.moring.question.application.QuestionRepository;
+import org.depromeet.sambad.moring.question.domain.Question;
 import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
 public class QuestionRepositoryImpl implements QuestionRepository {
 
 	private final QuestionJpaRepository questionJpaRepository;
+
+	@Override
+	public Optional<Question> findById(Long id) {
+		return questionJpaRepository.findById(id);
+	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/user/domain/User.java
+++ b/src/main/java/org/depromeet/sambad/moring/user/domain/User.java
@@ -7,7 +7,10 @@ import lombok.NoArgsConstructor;
 import org.depromeet.sambad.moring.auth.application.dto.AuthAttributes;
 import org.depromeet.sambad.moring.common.domain.BaseTimeEntity;
 import org.depromeet.sambad.moring.file.domain.FileEntity;
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -32,6 +35,9 @@ public class User extends BaseTimeEntity {
     private LoginProvider loginProvider;
 
     private String externalId;
+
+    @OneToMany(mappedBy = "user")
+    private List<MeetingMember> meetingMember = new ArrayList<>();
 
     private User(FileEntity imageFile, String name, String email, LoginProvider loginProvider, String externalId) {
         this.imageFile = imageFile;


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- 모임 및 모임원 관련 Entity를 추가합니다.
  - `meeting`
  - `meeting_member`
  - `meeting_type` 및 `types_per_meeting`
  - `hobby` 및 `meeting_member_hobby`
- `meeting_answer` 및 `meeting_question`과 연관관계를 지정합니다.

## 💡 코드 리뷰 시 참고 사항
- develop 브랜치 기반 애플리케이션 구동 가능한 정도까지만 만들어두었습니다.

## 🔗 ISSUE 링크
- resolved [SAMBAD-117](https://www.notion.so/depromeet/319c555c253d49f8a1216a7459d9bf9f?pvs=4)