### PR TITLE
[SAMBAD-125] FileUploader Profile 설정 및 구현체 의존 문제 수정

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/file/application/FileUploader.java
+++ b/src/main/java/org/depromeet/sambad/moring/file/application/FileUploader.java
@@ -1,15 +1,17 @@
 package org.depromeet.sambad.moring.file.application;
 
-import org.springframework.web.multipart.MultipartFile;
-
 import java.io.IOException;
 import java.util.UUID;
+
+import org.springframework.web.multipart.MultipartFile;
 
 public interface FileUploader {
 
 	String upload(MultipartFile file, String originalFileName) throws IOException;
 
 	String upload(String fileUrl) throws IOException;
+
+	void delete(Long Id);
 
 	default String getFileExtension(String fileName) {
 		int dotIndex = fileName.lastIndexOf('.');

--- a/src/main/java/org/depromeet/sambad/moring/file/infrastructure/LocalFileUploader.java
+++ b/src/main/java/org/depromeet/sambad/moring/file/infrastructure/LocalFileUploader.java
@@ -1,17 +1,18 @@
 package org.depromeet.sambad.moring.file.infrastructure;
 
-import lombok.RequiredArgsConstructor;
-import org.depromeet.sambad.moring.file.application.FileUploader;
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+
+import org.depromeet.sambad.moring.file.application.FileUploader;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.RequiredArgsConstructor;
 
 @Profile("local")
 @RequiredArgsConstructor
@@ -25,7 +26,7 @@ public class LocalFileUploader implements FileUploader {
 		Path uploadPath = generateUploadPath(originalFileName);
 
 		return Files.write(uploadPath, file.getBytes())
-				.toString();
+			.toString();
 	}
 
 	@Override
@@ -38,6 +39,11 @@ public class LocalFileUploader implements FileUploader {
 		}
 
 		return uploadPath.toString();
+	}
+
+	@Override
+	public void delete(Long Id) {
+		// TODO: 구현
 	}
 
 	private Path generateUploadPath(String originalFileName) throws IOException {

--- a/src/main/java/org/depromeet/sambad/moring/file/infrastructure/ObjectStorageFileUploader.java
+++ b/src/main/java/org/depromeet/sambad/moring/file/infrastructure/ObjectStorageFileUploader.java
@@ -6,25 +6,23 @@ import java.io.IOException;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.depromeet.sambad.moring.file.application.FileService;
 import org.depromeet.sambad.moring.file.application.FileUploader;
 import org.depromeet.sambad.moring.file.domain.FileEntity;
 import org.depromeet.sambad.moring.file.domain.FileRepository;
 import org.depromeet.sambad.moring.file.presentation.exception.ObjectStorageServerException;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.amazonaws.services.s3.model.S3Object;
-import com.amazonaws.services.s3.model.S3ObjectInputStream;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+@Profile({"dev", "prod"})
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -36,6 +34,7 @@ public class ObjectStorageFileUploader implements FileUploader {
 	private final AmazonS3 amazonS3;
 	private final FileRepository fileRepository;
 
+	@Override
 	public void delete(Long Id) {
 		FileEntity fileEntity = fileRepository.findById(Id);
 		try {


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- FileUploader 인터페이스에 빈 2개가 등록되는 문제로 정상 실행되지 않는 버그
- ObjectStorageUploader 구현체에 dev, prod profile 미설정 버그
- FileService에서 인터페이스 뿐 아니라 구현체인 ObjectStorageUploader에도 의존하는 문제

빠르게 샤샥 고쳐서 넣었으니, 정상 실행을 위해 빠르게 어프루브 해주시면 감사~~