### PR TITLE
[SAMBAD-131] 릴레이 질문 랜덤 대상자 조회

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberRandomGenerator.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberRandomGenerator.java
@@ -1,0 +1,10 @@
+package org.depromeet.sambad.moring.meeting.member.application;
+
+import java.util.List;
+
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
+
+public interface MeetingMemberRandomGenerator {
+
+	MeetingMember generate(List<MeetingMember> nextTargets);
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberRepository.java
@@ -16,7 +16,7 @@ public interface MeetingMemberRepository {
 
 	List<MeetingMember> findByMeetingIdOrderByName(Long meetingId);
 
-	List<MeetingMember> findNextTargetsByMeeting(Long meetingId, Long loginMeetingMemberId);
+	List<MeetingMember> findNextTargetsByMeeting(Long meetingId, Long loginMeetingMemberId, List<Long> excludeMemberIds);
 
 	boolean isUserExceedingMaxMeetings(Long userId, int maxMeetings);
 

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberService.java
@@ -32,6 +32,7 @@ import lombok.RequiredArgsConstructor;
 public class MeetingMemberService {
 
 	private final MeetingMemberValidator meetingMemberValidator;
+	private final MeetingMemberRandomGenerator meetingMemberRandomGenerator;
 	private final MeetingRepository meetingRepository;
 	private final MeetingMemberRepository meetingMemberRepository;
 	private final UserRepository userRepository;
@@ -109,7 +110,7 @@ public class MeetingMemberService {
 			throw new NoMeetingMemberInConditionException();
 		}
 
-		MeetingMember randomMember = nextTargetMembers.get(new Random().nextInt(nextTargetMembers.size()));
+		MeetingMember randomMember = meetingMemberRandomGenerator.generate(nextTargetMembers);
 		return MeetingMemberListResponseDetail.from(randomMember);
 	}
 

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberService.java
@@ -15,6 +15,7 @@ import org.depromeet.sambad.moring.meeting.member.presentation.exception.Meeting
 import org.depromeet.sambad.moring.meeting.member.presentation.exception.NoMeetingMemberInConditionException;
 import org.depromeet.sambad.moring.meeting.member.presentation.request.MeetingMemberPersistRequest;
 import org.depromeet.sambad.moring.meeting.member.presentation.response.MeetingMemberListResponse;
+import org.depromeet.sambad.moring.meeting.member.presentation.response.MeetingMemberListResponseDetail;
 import org.depromeet.sambad.moring.meeting.member.presentation.response.MeetingMemberPersistResponse;
 import org.depromeet.sambad.moring.meeting.member.presentation.response.MeetingMemberResponse;
 import org.depromeet.sambad.moring.user.domain.User;
@@ -71,14 +72,15 @@ public class MeetingMemberService {
 		return MeetingMemberResponse.from(getByUserIdAndMeetingId(userId, meetingId));
 	}
 
-	public MeetingMemberListResponse getNextTargets(Long userId) {
-		MeetingMember meetingMember = getByUserId(userId);
-		Meeting meeting = meetingMember.getMeeting();
-
-		List<MeetingMember> nextTargetMembers = meetingMemberRepository.findNextTargetsByMeeting(meeting.getId(),
-			meetingMember.getId());
-		return MeetingMemberListResponse.from(nextTargetMembers);
-	}
+	// TODO: 추후에 제거 여부 검토
+	// public MeetingMemberListResponse getNextTargets(Long userId) {
+	// 	MeetingMember meetingMember = getByUserId(userId);
+	// 	Meeting meeting = meetingMember.getMeeting();
+	//
+	// 	List<MeetingMember> nextTargetMembers = meetingMemberRepository.findNextTargetsByMeeting(meeting.getId(),
+	// 		meetingMember.getId());
+	// 	return MeetingMemberListResponse.from(nextTargetMembers);
+	// }
 
 	@Transactional
 	public MeetingMemberPersistResponse registerMeetingMember(
@@ -96,21 +98,20 @@ public class MeetingMemberService {
 		return MeetingMemberPersistResponse.from(meetingMember);
 	}
 
-	public MeetingMemberResponse getRandomMeetingMember(Long userId, Long meetingId, List<Long> excludeMemberIds) {
+	public MeetingMemberListResponseDetail getRandomMeetingMember(Long userId, Long meetingId,
+		List<Long> excludeMemberIds) {
 		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
 
-		List<MeetingMember> nextTargetMembers = meetingMemberRepository.findNextTargetsByMeeting(meetingId, userId).stream()
-			.filter(member -> !excludeMemberIds.contains(member.getId()))
-			.toList();
+		List<MeetingMember> nextTargetMembers = meetingMemberRepository.findNextTargetsByMeeting(meetingId, userId,
+			excludeMemberIds);
 
 		if (nextTargetMembers.isEmpty()) {
 			throw new NoMeetingMemberInConditionException();
 		}
 
 		MeetingMember randomMember = nextTargetMembers.get(new Random().nextInt(nextTargetMembers.size()));
-		return MeetingMemberResponse.from(randomMember);
+		return MeetingMemberListResponseDetail.from(randomMember);
 	}
-
 
 	private MeetingMember validateAndCreateMember(
 		Long userId, MeetingMemberPersistRequest request, Meeting meeting, User user

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberService.java
@@ -1,6 +1,7 @@
 package org.depromeet.sambad.moring.meeting.member.application;
 
 import java.util.List;
+import java.util.Random;
 
 import org.depromeet.sambad.moring.meeting.meeting.application.MeetingRepository;
 import org.depromeet.sambad.moring.meeting.meeting.domain.Meeting;
@@ -91,6 +92,17 @@ public class MeetingMemberService {
 		addHobbies(meetingMember, request);
 
 		return MeetingMemberPersistResponse.from(meetingMember);
+	}
+
+	public MeetingMemberResponse getRandomMeetingMember(Long userId, Long meetingId) {
+		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
+		List<MeetingMember> nextTargetMembers = meetingMemberRepository.findNextTargetsByMeeting(meetingId, userId);
+
+		Random random = new Random();
+		int randomIndex = random.nextInt(nextTargetMembers.size());
+
+		MeetingMember randomMember = nextTargetMembers.get(randomIndex);
+		return MeetingMemberResponse.from(randomMember);
 	}
 
 	private MeetingMember validateAndCreateMember(

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/infrastructure/MeetingMemberQueryRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/infrastructure/MeetingMemberQueryRepository.java
@@ -44,10 +44,11 @@ public class MeetingMemberQueryRepository {
 			.fetchFirst() != null;
 	}
 
-	public List<MeetingMember> findNextTargetsByMeetingId(Long meetingId, Long loginMeetingMemberId) {
+	public List<MeetingMember> findNextTargetsByMeetingId(Long meetingId, Long loginMeetingMemberId, List<Long> excludeMemberIds) {
 		return query.selectFrom(meetingMember)
 			.where(meetingMember.id.ne(loginMeetingMemberId),
-				meetingMember.meeting.id.eq(meetingId))
+				meetingMember.meeting.id.eq(meetingId),
+				meetingMember.id.notIn(excludeMemberIds))
 			.fetch();
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/infrastructure/MeetingMemberRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/infrastructure/MeetingMemberRepositoryImpl.java
@@ -37,8 +37,8 @@ public class MeetingMemberRepositoryImpl implements MeetingMemberRepository {
 	}
 
 	@Override
-	public List<MeetingMember> findNextTargetsByMeeting(Long meetingId, Long loginMeetingMemberId) {
-		return meetingMemberQueryRepository.findNextTargetsByMeetingId(meetingId, loginMeetingMemberId);
+	public List<MeetingMember> findNextTargetsByMeeting(Long meetingId, Long loginMeetingMemberId, List<Long> excludeMemberIds) {
+		return meetingMemberQueryRepository.findNextTargetsByMeetingId(meetingId, loginMeetingMemberId, excludeMemberIds);
 	}
 
 	@Override

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/infrastructure/RandomMeetingMemberGenerator.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/infrastructure/RandomMeetingMemberGenerator.java
@@ -1,0 +1,19 @@
+package org.depromeet.sambad.moring.meeting.member.infrastructure;
+
+import java.util.List;
+import java.util.Random;
+
+import org.depromeet.sambad.moring.meeting.member.application.MeetingMemberRandomGenerator;
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RandomMeetingMemberGenerator implements MeetingMemberRandomGenerator {
+
+	@Override
+	public MeetingMember generate(List<MeetingMember> nextTargets) {
+		Random random = new Random();
+		int index = random.nextInt(nextTargets.size());
+		return nextTargets.get(index);
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/MeetingMemberController.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/MeetingMemberController.java
@@ -2,6 +2,8 @@ package org.depromeet.sambad.moring.meeting.member.presentation;
 
 import static org.springframework.http.HttpStatus.CREATED;
 
+import java.util.List;
+
 import org.depromeet.sambad.moring.meeting.member.application.MeetingMemberService;
 import org.depromeet.sambad.moring.meeting.member.presentation.request.MeetingMemberPersistRequest;
 import org.depromeet.sambad.moring.meeting.member.presentation.response.MeetingMemberListResponse;
@@ -98,14 +100,16 @@ public class MeetingMemberController {
 	@Operation(summary = "다음 랜덤 질문 대상자 조회", description = "다음 릴레이 질문 랜덤 대상자를 조회합니다.")
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "랜덤 질문 대상자 조회 성공"),
-		@ApiResponse(responseCode = "403", description = "USER_NOT_MEMBER_OF_MEETING")
+		@ApiResponse(responseCode = "403", description = "USER_NOT_MEMBER_OF_MEETING"),
+		@ApiResponse(responseCode = "404", description = "NO_MEETING_MEMBER_IN_CONDITION")
 	})
 	@GetMapping("/questions/target")
 	public ResponseEntity<MeetingMemberResponse> getRandomQuestionMember(
 		@UserId Long userId,
-		@Parameter(description = "모임 ID", example = "1", required = true) @PathVariable("meetingId") Long meetingId
+		@Parameter(description = "모임 ID", example = "1", required = true) @PathVariable("meetingId") Long meetingId,
+		@Parameter(description = "랜덤 대상자 제외 ID", example = "2") @RequestParam("excludeMemberIds") List<Long> excludeMemberIds
 	) {
-		MeetingMemberResponse response = meetingMemberService.getRandomMeetingMember(userId, meetingId);
+		MeetingMemberResponse response = meetingMemberService.getRandomMeetingMember(userId, meetingId, excludeMemberIds);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/MeetingMemberController.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/MeetingMemberController.java
@@ -107,7 +107,7 @@ public class MeetingMemberController {
 	public ResponseEntity<MeetingMemberResponse> getRandomQuestionMember(
 		@UserId Long userId,
 		@Parameter(description = "모임 ID", example = "1", required = true) @PathVariable("meetingId") Long meetingId,
-		@Parameter(description = "랜덤 대상자 제외 ID", example = "2") @RequestParam("excludeMemberIds") List<Long> excludeMemberIds
+		@Parameter(description = "랜덤 대상자 제외할 모임원 ID 리스트", example = "2") @RequestParam("excludeMemberIds") List<Long> excludeMemberIds
 	) {
 		MeetingMemberResponse response = meetingMemberService.getRandomMeetingMember(userId, meetingId, excludeMemberIds);
 		return ResponseEntity.ok(response);

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/MeetingMemberController.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/MeetingMemberController.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.depromeet.sambad.moring.meeting.member.application.MeetingMemberService;
 import org.depromeet.sambad.moring.meeting.member.presentation.request.MeetingMemberPersistRequest;
 import org.depromeet.sambad.moring.meeting.member.presentation.response.MeetingMemberListResponse;
+import org.depromeet.sambad.moring.meeting.member.presentation.response.MeetingMemberListResponseDetail;
 import org.depromeet.sambad.moring.meeting.member.presentation.response.MeetingMemberPersistResponse;
 import org.depromeet.sambad.moring.meeting.member.presentation.response.MeetingMemberResponse;
 import org.depromeet.sambad.moring.user.presentation.resolver.UserId;
@@ -104,12 +105,12 @@ public class MeetingMemberController {
 		@ApiResponse(responseCode = "404", description = "NO_MEETING_MEMBER_IN_CONDITION")
 	})
 	@GetMapping("/questions/target")
-	public ResponseEntity<MeetingMemberResponse> getRandomQuestionMember(
+	public ResponseEntity<MeetingMemberListResponseDetail> getRandomQuestionMember(
 		@UserId Long userId,
 		@Parameter(description = "모임 ID", example = "1", required = true) @PathVariable("meetingId") Long meetingId,
 		@Parameter(description = "랜덤 대상자 제외할 모임원 ID 리스트", example = "2") @RequestParam("excludeMemberIds") List<Long> excludeMemberIds
 	) {
-		MeetingMemberResponse response = meetingMemberService.getRandomMeetingMember(userId, meetingId, excludeMemberIds);
+		MeetingMemberListResponseDetail response = meetingMemberService.getRandomMeetingMember(userId, meetingId, excludeMemberIds);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/MeetingMemberController.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/MeetingMemberController.java
@@ -1,6 +1,6 @@
 package org.depromeet.sambad.moring.meeting.member.presentation;
 
-import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.HttpStatus.CREATED;
 
 import org.depromeet.sambad.moring.meeting.member.application.MeetingMemberService;
 import org.depromeet.sambad.moring.meeting.member.presentation.request.MeetingMemberPersistRequest;
@@ -93,5 +93,19 @@ public class MeetingMemberController {
 	) {
 		MeetingMemberPersistResponse response = meetingMemberService.registerMeetingMember(userId, code, request);
 		return ResponseEntity.status(CREATED).body(response);
+	}
+
+	@Operation(summary = "다음 랜덤 질문 대상자 조회", description = "다음 릴레이 질문 랜덤 대상자를 조회합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "랜덤 질문 대상자 조회 성공"),
+		@ApiResponse(responseCode = "403", description = "USER_NOT_MEMBER_OF_MEETING")
+	})
+	@GetMapping("/questions/target")
+	public ResponseEntity<MeetingMemberResponse> getRandomQuestionMember(
+		@UserId Long userId,
+		@Parameter(description = "모임 ID", example = "1", required = true) @PathVariable("meetingId") Long meetingId
+	) {
+		MeetingMemberResponse response = meetingMemberService.getRandomMeetingMember(userId, meetingId);
+		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/exception/MeetingMemberExceptionCode.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/exception/MeetingMemberExceptionCode.java
@@ -17,6 +17,7 @@ public enum MeetingMemberExceptionCode implements ExceptionCode {
     USER_NOT_MEMBER_OF_MEETING(FORBIDDEN, "사용자가 해당 모임에 가입되어 있지 않습니다."),
 
     MEETING_MEMBER_NOT_FOUND(NOT_FOUND, "모임 참여자를 찾을 수 없습니다."),
+    NO_MEETING_MEMBER_IN_CONDITION(NOT_FOUND, "조건에 맞는 모임 참여자가 없습니다."),
 
     MEETING_MEMBER_ALREADY_EXISTS(CONFLICT, "이미 모임에 가입되어 있습니다."),
     ;

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/exception/NoMeetingMemberInConditionException.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/exception/NoMeetingMemberInConditionException.java
@@ -1,0 +1,11 @@
+package org.depromeet.sambad.moring.meeting.member.presentation.exception;
+
+import static org.depromeet.sambad.moring.meeting.member.presentation.exception.MeetingMemberExceptionCode.NO_MEETING_MEMBER_IN_CONDITION;
+
+import org.depromeet.sambad.moring.common.exception.BusinessException;
+
+public class NoMeetingMemberInConditionException extends BusinessException {
+	public NoMeetingMemberInConditionException() {
+		super(NO_MEETING_MEMBER_IN_CONDITION);
+	}
+}


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- 릴레이 질문 랜덤 대상자 조회 api를 구현하였습니다.
- 모임장도 릴레이 질문 랜덤 대상자에 포함될 수 있습니다.

  ```java
    public MeetingMemberResponse getRandomMeetingMember(Long userId, Long meetingId) {
		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
		List<MeetingMember> nextTargetMembers = meetingMemberRepository.findNextTargetsByMeeting(meetingId, userId);

		Random random = new Random();
		int randomIndex = random.nextInt(nextTargetMembers.size());

		MeetingMember randomMember = nextTargetMembers.get(randomIndex);
		return MeetingMemberResponse.from(randomMember);
	}
  ```


## 💡 코드 리뷰 시 참고 사항
- 스웨거 테스트 결과
<img width="1333" alt="스크린샷 2024-07-25 오전 12 16 26" src="https://github.com/user-attachments/assets/9025655b-4ed0-4544-8aff-6702c39335f3">

## 🔗 ISSUE 링크
- resolved [SAMBAD-이슈번호]()