### PR TITLE
[SAMBAD-133] 가장 많이 선택된 답변 / 나와 같은 답변을 선택한 멤버 조회 기능 추가

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/application/MeetingAnswerRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/application/MeetingAnswerRepository.java
@@ -1,11 +1,20 @@
 package org.depromeet.sambad.moring.meeting.answer.application;
 
+import java.util.List;
+
 import org.depromeet.sambad.moring.meeting.answer.domain.MeetingAnswer;
 import org.depromeet.sambad.moring.meeting.answer.presentation.response.MyMeetingAnswerListResponse;
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
 
 public interface MeetingAnswerRepository {
 
 	void save(MeetingAnswer meetingAnswer);
+
+	List<MeetingAnswer> findMostSelected(Long meetingQuestionId);
+
+	List<MeetingAnswer> findByMeetingQuestionIdAndMeetingMemberId(Long meetingQuestionId, Long meetingMemberId);
+
+	List<MeetingMember> findMeetingMembersSelectWith(Long questionId, List<Long> answerIds);
 
 	boolean existsByMeetingMember(Long meetingQuestionId, Long meetingMemberId);
 

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/application/MeetingAnswerResultService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/application/MeetingAnswerResultService.java
@@ -1,0 +1,55 @@
+package org.depromeet.sambad.moring.meeting.answer.application;
+
+import java.util.List;
+
+import org.depromeet.sambad.moring.meeting.answer.domain.MeetingAnswer;
+import org.depromeet.sambad.moring.meeting.answer.presentation.response.SelectedAnswerResponse;
+import org.depromeet.sambad.moring.meeting.member.application.MeetingMemberService;
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMemberValidator;
+import org.depromeet.sambad.moring.meeting.question.application.MeetingQuestionRepository;
+import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
+import org.depromeet.sambad.moring.meeting.question.presentation.exception.NotFoundMeetingQuestion;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class MeetingAnswerResultService {
+
+	private final MeetingMemberService meetingMemberService;
+	private final MeetingQuestionRepository meetingQuestionRepository;
+	private final MeetingAnswerRepository meetingAnswerRepository;
+	private final MeetingMemberValidator meetingMemberValidator;
+
+	public SelectedAnswerResponse getMostSelectedAnswer(Long userId, Long meetingId, Long meetingQuestionId) {
+		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
+
+		MeetingQuestion meetingQuestion = meetingQuestionRepository.findByMeetingIdAndMeetingQuestionId(
+				meetingId, meetingQuestionId)
+			.orElseThrow(NotFoundMeetingQuestion::new);
+
+		List<MeetingAnswer> answers = meetingAnswerRepository.findMostSelected(meetingQuestion.getId());
+
+		List<MeetingMember> members = meetingAnswerRepository.findMeetingMembersSelectWith(
+			meetingQuestionId, MeetingAnswer.getAnswerIds(answers));
+
+		return SelectedAnswerResponse.from(members, answers);
+	}
+
+	public SelectedAnswerResponse getSelectedSameAnswer(Long userId, Long meetingId, Long meetingQuestionId) {
+		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
+		MeetingMember meetingMember = meetingMemberService.getByUserIdAndMeetingId(userId, meetingId);
+
+		List<MeetingAnswer> answers = meetingAnswerRepository.findByMeetingQuestionIdAndMeetingMemberId(
+			meetingQuestionId, meetingMember.getId());
+
+		List<MeetingMember> members = meetingAnswerRepository.findMeetingMembersSelectWith(
+			meetingQuestionId, MeetingAnswer.getAnswerIds(answers));
+
+		return SelectedAnswerResponse.from(members, answers);
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/domain/MeetingAnswer.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/domain/MeetingAnswer.java
@@ -1,5 +1,8 @@
 package org.depromeet.sambad.moring.meeting.answer.domain;
 
+import java.util.List;
+import java.util.Objects;
+
 import org.depromeet.sambad.moring.answer.domain.Answer;
 import org.depromeet.sambad.moring.common.domain.BaseTimeEntity;
 import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
@@ -45,5 +48,16 @@ public class MeetingAnswer extends BaseTimeEntity {
 		this.meetingQuestion = meetingQuestion;
 		this.answer = answer;
 		this.meetingMember = meetingMember;
+	}
+
+	public String getAnswerContent() {
+		return answer.getContent();
+	}
+
+	public static List<Long> getAnswerIds(List<MeetingAnswer> answers) {
+		return answers.stream()
+			.map(meetingAnswer -> meetingAnswer.answer.getId())
+			.filter(Objects::nonNull)
+			.toList();
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerJpaRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerJpaRepository.java
@@ -1,9 +1,13 @@
 package org.depromeet.sambad.moring.meeting.answer.infrastructure;
 
+import java.util.List;
+
 import org.depromeet.sambad.moring.meeting.answer.domain.MeetingAnswer;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MeetingAnswerJpaRepository extends JpaRepository<MeetingAnswer, Long> {
 
 	boolean existsByMeetingQuestionIdAndMeetingMemberId(Long meetingQuestionId, Long meetingMemberId);
+
+	List<MeetingAnswer> findByMeetingQuestionIdAndMeetingMemberId(Long meetingQuestionId, Long meetingMemberId);
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerQueryRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerQueryRepository.java
@@ -1,0 +1,62 @@
+package org.depromeet.sambad.moring.meeting.answer.infrastructure;
+
+import static com.querydsl.core.types.dsl.Expressions.*;
+import static org.depromeet.sambad.moring.meeting.answer.domain.QMeetingAnswer.*;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.depromeet.sambad.moring.meeting.answer.domain.MeetingAnswer;
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.StringExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Repository
+public class MeetingAnswerQueryRepository {
+
+	private final JPAQueryFactory query;
+
+	// TODO: 가장 많이 선택된 답변이 여러개일 수 있으나, 현재 로직은 하나만 반환. 추후 기획에 따라 수정 필요.
+	public List<MeetingAnswer> findMostSelectedMeetingAnswer(Long meetingQuestionId) {
+		Long mostSelectedAnswerId = query.select(meetingAnswer.answer.id)
+			.from(meetingAnswer)
+			.where(meetingAnswer.meetingQuestion.id.eq(meetingQuestionId))
+			.groupBy(meetingAnswer.answer.id)
+			.orderBy(meetingAnswer.answer.id.count().desc())
+			.fetchFirst();
+
+		return query.selectFrom(meetingAnswer)
+			.where(meetingAnswer.answer.id.eq(mostSelectedAnswerId))
+			.fetch();
+	}
+
+	/**
+	 * 주어진 답변 리스트와 동일한 답변을 선택한 회원을 조회합니다.<br />
+	 * "," 기반으로 유저의 답변 리스트를 CONCAT하여 비교합니다.
+	 */
+	public List<MeetingMember> findSameAnswerSelectMembers(Long meetingQuestionId, List<Long> answerIds) {
+		StringExpression answerIdsExpression = stringTemplate(
+			"GROUP_CONCAT(DISTINCT {0})", meetingAnswer.answer.id)
+			.as("answer_ids");
+
+		List<Tuple> answerIdsByMember = query.select(meetingAnswer.meetingMember, answerIdsExpression)
+			.from(meetingAnswer)
+			.where(meetingAnswer.meetingQuestion.id.eq(meetingQuestionId)
+				.and(meetingAnswer.answer.id.in(answerIds)))
+			.groupBy(meetingAnswer.meetingMember.id)
+			.fetch();
+
+		String answerIdsToString = String.join(",", answerIds.stream().map(String::valueOf).toList());
+
+		return answerIdsByMember.stream()
+			.filter(tuple -> Objects.equals(tuple.get(answerIdsExpression), answerIdsToString))
+			.map(tuple -> tuple.get(meetingAnswer.meetingMember))
+			.toList();
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerRepositoryImpl.java
@@ -12,6 +12,7 @@ import org.depromeet.sambad.moring.meeting.answer.domain.MeetingAnswer;
 import org.depromeet.sambad.moring.meeting.answer.infrastructure.dto.MyMeetingAnswerResponseCustom;
 import org.depromeet.sambad.moring.meeting.answer.presentation.response.MyMeetingAnswerListResponse;
 import org.depromeet.sambad.moring.meeting.comment.domain.comment.MeetingQuestionComment;
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.types.Projections;
@@ -26,10 +27,26 @@ public class MeetingAnswerRepositoryImpl implements MeetingAnswerRepository {
 
 	private final MeetingAnswerJpaRepository meetingAnswerJpaRepository;
 	private final JPAQueryFactory queryFactory;
+	private final MeetingAnswerQueryRepository meetingAnswerQueryRepository;
 
 	@Override
 	public void save(MeetingAnswer meetingAnswer) {
 		meetingAnswerJpaRepository.save(meetingAnswer);
+	}
+
+	@Override
+	public List<MeetingAnswer> findMostSelected(Long meetingQuestionId) {
+		return meetingAnswerQueryRepository.findMostSelectedMeetingAnswer(meetingQuestionId);
+	}
+
+	@Override
+	public List<MeetingAnswer> findByMeetingQuestionIdAndMeetingMemberId(Long meetingQuestionId, Long meetingMemberId) {
+		return meetingAnswerJpaRepository.findByMeetingQuestionIdAndMeetingMemberId(meetingQuestionId, meetingMemberId);
+	}
+
+	@Override
+	public List<MeetingMember> findMeetingMembersSelectWith(Long questionId, List<Long> answerIds) {
+		return meetingAnswerQueryRepository.findSameAnswerSelectMembers(questionId, answerIds);
 	}
 
 	@Override

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/presentation/MeetingAnswerController.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/presentation/MeetingAnswerController.java
@@ -3,6 +3,8 @@ package org.depromeet.sambad.moring.meeting.answer.presentation;
 import org.depromeet.sambad.moring.meeting.answer.application.MeetingAnswerService;
 import org.depromeet.sambad.moring.meeting.answer.presentation.request.MeetingAnswerRequest;
 import org.depromeet.sambad.moring.meeting.answer.presentation.response.MyMeetingAnswerListResponse;
+import org.depromeet.sambad.moring.meeting.answer.presentation.response.SelectedAnswerResponse;
+import org.depromeet.sambad.moring.meeting.answer.application.MeetingAnswerResultService;
 import org.depromeet.sambad.moring.user.presentation.resolver.UserId;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -29,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 public class MeetingAnswerController {
 
 	private final MeetingAnswerService meetingAnswerService;
+	private final MeetingAnswerResultService meetingAnswerResultService;
 
 	@Operation(summary = "모임원 답변 등록")
 	@ApiResponses(value = {
@@ -61,6 +64,44 @@ public class MeetingAnswerController {
 		@Parameter(description = "모임 ID", example = "1", required = true) @PathVariable("meetingId") Long meetingId
 	) {
 		MyMeetingAnswerListResponse response = meetingAnswerService.getMyList(userId, meetingId);
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "가장 많이 선택된 답변 조회", description = "가장 많이 선택된 답변과 이를 선택한 모임원 리스트를 조회합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "403", description = "USER_NOT_MEMBER_OF_MEETING"),
+		@ApiResponse(responseCode = "404", description = "NOT_FOUND_MEETING_QUESTION")
+	})
+	@GetMapping("/meetings/{meetingId}/questions/{questionId}/answers/most-selected")
+	public ResponseEntity<SelectedAnswerResponse> getMostSelectedMeetingAnswer(
+		@UserId Long userId,
+		@Parameter(description = "모임 ID", example = "1", required = true) @PathVariable Long meetingId,
+		@Parameter(description = "모임 질문 ID", example = "1", required = true)
+		@PathVariable(name = "questionId") Long meetingQuestionId
+	) {
+		SelectedAnswerResponse response = meetingAnswerResultService.getMostSelectedAnswer(
+			userId, meetingId, meetingQuestionId);
+
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "같은 답변을 선택한 모임원 리스트 조회", description = "같은 답변을 선택한 모임원 리스트를 조회합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "403", description = "USER_NOT_MEMBER_OF_MEETING"),
+		@ApiResponse(responseCode = "404", description = "MEETING_MEMBER_NOT_FOUND")
+	})
+	@GetMapping("/meetings/{meetingId}/questions/{questionId}/answers/selected-same")
+	public ResponseEntity<SelectedAnswerResponse> getSelectedSameMeetingAnswers(
+		@UserId Long userId,
+		@Parameter(description = "모임 ID", example = "1", required = true) @PathVariable Long meetingId,
+		@Parameter(description = "모임 질문 ID", example = "1", required = true)
+		@PathVariable(name = "questionId") Long meetingQuestionId
+	) {
+		SelectedAnswerResponse response = meetingAnswerResultService.getSelectedSameAnswer(
+			userId, meetingId, meetingQuestionId);
+
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/presentation/response/SelectedAnswerResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/presentation/response/SelectedAnswerResponse.java
@@ -1,0 +1,33 @@
+package org.depromeet.sambad.moring.meeting.answer.presentation.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
+import java.util.List;
+
+import org.depromeet.sambad.moring.meeting.answer.domain.MeetingAnswer;
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
+import org.depromeet.sambad.moring.meeting.member.presentation.response.MeetingMemberListResponse;
+import org.depromeet.sambad.moring.meeting.member.presentation.response.MeetingMemberListResponseDetail;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SelectedAnswerResponse(
+	@Schema(description = "답변 내용", example = "[\"토마토\"]", requiredMode = REQUIRED)
+	List<String> content,
+	@Schema(description = "답변 수", example = "3", requiredMode = REQUIRED)
+	int count,
+	@Schema(description = "선택한 멤버들", requiredMode = REQUIRED)
+	List<MeetingMemberListResponseDetail> selectedMembers
+) {
+	public static SelectedAnswerResponse from(List<MeetingMember> members,
+		List<MeetingAnswer> answers) {
+		return new SelectedAnswerResponse(
+			answers.stream()
+				.map(MeetingAnswer::getAnswerContent)
+				.toList(),
+			answers.size(),
+			MeetingMemberListResponse.from(members).contents()
+		);
+	}
+}
+


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 📝 개요
- `GET /meetings/{meetingId}/questions/{questionId}/answers/most-selected` 을 통해 가장 많이 선택된 답변과, 해당 답변을 선택한 멤버를 조회합니다.
- `GET "/meetings/{meetingId}/questions/{questionId}/answers/selected-same` 을 통해 나와 같은 답변을 선택한 멤버를 조회합니다.
- 본래 두 조회 결과를 한 API로 합쳐 제공하려 했으나, 합치는 작업이 더 공수가 커 분리했습니다.

## 🔗 ISSUE 링크
- resolved [SAMBAD-133](https://www.notion.so/depromeet/4f00138f6903430d95cafe05cf5d8966?pvs=4)