### PR TITLE
[SAMBAD-159] 유저 기본 정보 조회 API 스펙 확정

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/user/presentation/UserController.java
+++ b/src/main/java/org/depromeet/sambad/moring/user/presentation/UserController.java
@@ -8,20 +8,24 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "유저", description = "유저 인증정보 관리 api / 담당자 : 권기준")
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/users")
+@RequestMapping("/v1/users")
 public class UserController {
 
 	private final UserService userService;
 
-	/**
-	 * TODO: API 스펙 확정되면 스웨거 추가 필요
-	 */
+	@Operation(
+		summary = "내 정보 조회",
+		description = "현재 로그인 중인 유저의 정보를 조회합니다. 모임원 정보가 아닌 유저 정보로, 모임원 정보 설정 시 초기값 등으로 활용해주시면 됩니다."
+	)
+	@ApiResponse(responseCode = "200", description = "성공")
 	@GetMapping("/me")
 	public ResponseEntity<UserResponse> getUser(@UserId Long userId) {
 		UserResponse response = userService.findByUserId(userId);

--- a/src/main/java/org/depromeet/sambad/moring/user/presentation/response/UserResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/user/presentation/response/UserResponse.java
@@ -19,10 +19,10 @@ public record UserResponse(
 	String profileImageFileUrl,
 
 	@Schema(description = "생성일", example = "2021-07-01T00:00:00", requiredMode = REQUIRED)
-	LocalDateTime createAt,
+	LocalDateTime createdAt,
 
 	@Schema(description = "수정일", example = "2021-07-01T00:00:00", requiredMode = REQUIRED)
-	LocalDateTime updateAt
+	LocalDateTime updatedAt
 ) {
 
 	public static UserResponse from(User user) {

--- a/src/main/java/org/depromeet/sambad/moring/user/presentation/response/UserResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/user/presentation/response/UserResponse.java
@@ -1,18 +1,28 @@
 package org.depromeet.sambad.moring.user.presentation.response;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
 import java.time.LocalDateTime;
 
 import org.depromeet.sambad.moring.user.domain.User;
 
-/**
- * TODO: 로그인 성공 여부 확인 용으로 임시로 만들었으며, 제공할 정보 및 API 스펙이 확정되면 수정이 필요합니다.
- */
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record UserResponse(
+	@Schema(description = "유저 이름", example = "홍길동", requiredMode = REQUIRED)
 	String name,
+
+	@Schema(description = "유저 이메일", example = "example@abc.com", requiredMode = REQUIRED)
 	String email,
+
+	@Schema(description = "프로필 이미지 경로", example = "https://example.com/profile.jpg", requiredMode = REQUIRED)
 	String profileImageFileUrl,
-	LocalDateTime createdAt,
-	LocalDateTime updatedAt
+
+	@Schema(description = "생성일", example = "2021-07-01T00:00:00", requiredMode = REQUIRED)
+	LocalDateTime createAt,
+
+	@Schema(description = "수정일", example = "2021-07-01T00:00:00", requiredMode = REQUIRED)
+	LocalDateTime updateAt
 ) {
 
 	public static UserResponse from(User user) {


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- 기존 TODO로 남아있던 유저 기본 정보 조회 기능의 API 스펙을 확정짓습니다.

## 🔗 ISSUE 링크
- resolved [SAMBAD-159](https://www.notion.so/depromeet/User-a119d67414ee4dfb90e533238e120fd5?pvs=4)