### PR TITLE
[SAMBAD-130] 랜덤 질문 선택 API 구현

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/question/application/QuestionRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/question/application/QuestionRepository.java
@@ -1,5 +1,6 @@
 package org.depromeet.sambad.moring.question.application;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.depromeet.sambad.moring.question.domain.Question;
@@ -11,4 +12,6 @@ public interface QuestionRepository {
 	Optional<Question> findById(Long id);
 
 	QuestionListResponse findQuestionsByMeeting(Long meetingId, Pageable pageable);
+
+	List<Question> findAllByNotInQuestionIds(List<Long> excludeQuestionIds);
 }

--- a/src/main/java/org/depromeet/sambad/moring/question/application/QuestionService.java
+++ b/src/main/java/org/depromeet/sambad/moring/question/application/QuestionService.java
@@ -1,11 +1,16 @@
 package org.depromeet.sambad.moring.question.application;
 
+import java.util.List;
+import java.util.Random;
+
 import org.depromeet.sambad.moring.meeting.meeting.domain.Meeting;
 import org.depromeet.sambad.moring.meeting.member.application.MeetingMemberService;
 import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
 import org.depromeet.sambad.moring.question.domain.Question;
+import org.depromeet.sambad.moring.question.presentation.exception.NotFoundAvailableQuestionException;
 import org.depromeet.sambad.moring.question.presentation.exception.NotFoundQuestionException;
 import org.depromeet.sambad.moring.question.presentation.response.QuestionListResponse;
+import org.depromeet.sambad.moring.question.presentation.response.QuestionResponse;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,5 +35,16 @@ public class QuestionService {
 		MeetingMember loginMember = meetingMemberService.getByUserIdAndMeetingId(userId, meetingId);
 		Meeting meeting = loginMember.getMeeting();
 		return questionRepository.findQuestionsByMeeting(meeting.getId(), PageRequest.of(page, size));
+	}
+
+	public QuestionResponse getRandomOne(List<Long> excludeQuestionIds) {
+		List<Question> questions = questionRepository.findAllByNotInQuestionIds(excludeQuestionIds);
+
+		if (questions.isEmpty()) {
+			throw new NotFoundAvailableQuestionException();
+		}
+
+		Question randomQuestion = questions.get(new Random().nextInt(questions.size()));
+		return QuestionResponse.from(randomQuestion);
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/question/infrastructure/QuestionRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moring/question/infrastructure/QuestionRepositoryImpl.java
@@ -68,6 +68,14 @@ public class QuestionRepositoryImpl implements QuestionRepository {
 		return QuestionListResponse.of(questionSummaryResponses, PageableResponse.of(pageable, totalElementIds));
 	}
 
+	@Override
+	public List<Question> findAllByNotInQuestionIds(List<Long> excludeQuestionIds) {
+		return queryFactory
+			.selectFrom(question)
+			.where(question.id.notIn(excludeQuestionIds))
+			.fetch();
+	}
+
 	private static BooleanExpression questionEq() {
 		return meetingQuestion.question.id.eq(question.id);
 	}

--- a/src/main/java/org/depromeet/sambad/moring/question/presentation/QuestionController.java
+++ b/src/main/java/org/depromeet/sambad/moring/question/presentation/QuestionController.java
@@ -1,5 +1,7 @@
 package org.depromeet.sambad.moring.question.presentation;
 
+import java.util.List;
+
 import org.depromeet.sambad.moring.question.application.QuestionService;
 import org.depromeet.sambad.moring.question.domain.Question;
 import org.depromeet.sambad.moring.question.presentation.response.QuestionListResponse;
@@ -60,5 +62,18 @@ public class QuestionController {
 	) {
 		QuestionListResponse response = questionService.findQuestions(userId, meetingId, page, size);
 		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "랜덤 질문 조회", description = "모임원이 질문을 선정할 때, 랜덤으로 질문을 추천해주는 API 입니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "랜덤 질문 조회 성공"),
+		@ApiResponse(responseCode = "404", description = "NOT_FOUND_AVAILABLE_QUESTION")
+	})
+	@GetMapping("/questions/random")
+	public ResponseEntity<QuestionResponse> findRandomOne(
+		@Parameter(description = "제외할 질문 ID 리스트", example = "1,2,3") @RequestParam List<Long> excludeQuestionIds
+	) {
+		QuestionResponse randomOne = questionService.getRandomOne(excludeQuestionIds);
+		return ResponseEntity.ok(randomOne);
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/question/presentation/exception/NotFoundAvailableQuestionException.java
+++ b/src/main/java/org/depromeet/sambad/moring/question/presentation/exception/NotFoundAvailableQuestionException.java
@@ -1,0 +1,11 @@
+package org.depromeet.sambad.moring.question.presentation.exception;
+
+import static org.depromeet.sambad.moring.question.presentation.exception.QuestionExceptionCode.*;
+
+import org.depromeet.sambad.moring.common.exception.BusinessException;
+
+public class NotFoundAvailableQuestionException extends BusinessException {
+	public NotFoundAvailableQuestionException() {
+		super(NOT_FOUND_AVAILABLE_QUESTION);
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moring/question/presentation/exception/QuestionExceptionCode.java
+++ b/src/main/java/org/depromeet/sambad/moring/question/presentation/exception/QuestionExceptionCode.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 public enum QuestionExceptionCode implements ExceptionCode {
 
 	NOT_FOUND_QUESTION(NOT_FOUND, "모임 릴레이 질문이 존재하지 않습니다."),
+	NOT_FOUND_AVAILABLE_QUESTION(NOT_FOUND, "사용 가능한 질문이 존재하지 않습니다."),
 	;
 
 	private final HttpStatus status;


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- 서비스에 존재하는 질문 중, 랜덤한 질문 한 가지를 선택하는 API를 구현합니다.

## 💡 코드 리뷰 시 참고 사항
- 구현하면서 몇 가지 서비스 관점의 고민이 존재했는데, 일단 스펙대로만 구현했고 추후 팀끼리 논의해보면 좋을 내용입니다.
  - 모임 내에서 이미 등록되었던 질문은 추천해주지 않기
  - 카테고리 별 추천, 사용자 경험 기반 추천, AI 기반 추천 등 (이 모임에 더 어울리는 질문!)

## 🔗 ISSUE 링크
- resolved [SAMBAD-130](https://www.notion.so/depromeet/7c90217221c84a96b2e17e6d406a1fb5?pvs=4)