### PR TITLE
[SAMBAD-160] 회원가입 시 기본 프로필 이미지 등록 로직 구현

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/auth/application/AuthService.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/application/AuthService.java
@@ -66,6 +66,6 @@ public class AuthService {
 
 		return StringUtils.hasText(profileImageUrl)
 			? fileService.uploadAndSave(profileImageUrl)
-			: null;
+			: fileService.getRandomProfileImage();
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/file/application/FileService.java
+++ b/src/main/java/org/depromeet/sambad/moring/file/application/FileService.java
@@ -1,19 +1,21 @@
 package org.depromeet.sambad.moring.file.application;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.depromeet.sambad.moring.file.domain.FileEntity;
 import org.depromeet.sambad.moring.file.domain.FileRepository;
 import org.depromeet.sambad.moring.file.presentation.exception.NotFoundFileException;
 import org.depromeet.sambad.moring.file.presentation.response.FileUrlResponse;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Service
+@Transactional(readOnly = true)
 public class FileService {
 
 	private final FileUploader fileUploader;
@@ -46,6 +48,16 @@ public class FileService {
 		} catch (IOException e) {
 			throw new RuntimeException("Failed to upload file", e);
 		}
+	}
+
+	public FileEntity getRandomProfileImage() {
+		List<FileEntity> defaultFiles = fileRepository.findAllByIsDefaultTrue();
+
+		if (defaultFiles.isEmpty()) {
+			return null;
+		}
+
+		return defaultFiles.get((int) (Math.random() * defaultFiles.size()));
 	}
 
 	private boolean isNotExistFile(Long fileId) {

--- a/src/main/java/org/depromeet/sambad/moring/file/domain/FileEntity.java
+++ b/src/main/java/org/depromeet/sambad/moring/file/domain/FileEntity.java
@@ -29,9 +29,17 @@ public class FileEntity extends BaseTimeEntity {
 
 	private String physicalPath;
 
-	private FileEntity(String logicalName, String physicalPath) {
+	/*
+	 * TODO: ERD에 기반하면, 사용자 업로드 file과 시스템 file이 슈퍼-서브타입으로서 구분되어야 합니다.
+	 *  추후 마이그레이션 작업을 수행할 예정입니다.
+	 */
+	@Column(columnDefinition = "TINYINT")
+	private Boolean isDefault;
+
+	private FileEntity(String logicalName, String physicalPath, Boolean isDefault) {
 		this.logicalName = logicalName;
 		this.physicalPath = physicalPath;
+		this.isDefault = isDefault;
 	}
 
 	public static FileEntity of(String logicalName, String filePath) {
@@ -39,6 +47,6 @@ public class FileEntity extends BaseTimeEntity {
 			throw new ObjectStorageServerException();
 		}
 
-		return new FileEntity(logicalName, filePath);
+		return new FileEntity(logicalName, filePath, false);
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/file/domain/FileRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/file/domain/FileRepository.java
@@ -1,5 +1,7 @@
 package org.depromeet.sambad.moring.file.domain;
 
+import java.util.List;
+
 public interface FileRepository {
 
 	FileEntity save(FileEntity fileEntity);
@@ -9,4 +11,6 @@ public interface FileRepository {
 	void deleteById(Long id);
 
 	FileEntity findById(Long id);
+
+	List<FileEntity> findAllByIsDefaultTrue();
 }

--- a/src/main/java/org/depromeet/sambad/moring/file/infrastructure/FileJpaRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/file/infrastructure/FileJpaRepository.java
@@ -1,7 +1,10 @@
 package org.depromeet.sambad.moring.file.infrastructure;
 
+import java.util.List;
+
 import org.depromeet.sambad.moring.file.domain.FileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FileJpaRepository extends JpaRepository<FileEntity, Long> {
+	List<FileEntity> findAllByIsDefaultTrue();
 }

--- a/src/main/java/org/depromeet/sambad/moring/file/infrastructure/FileRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moring/file/infrastructure/FileRepositoryImpl.java
@@ -1,5 +1,7 @@
 package org.depromeet.sambad.moring.file.infrastructure;
 
+import java.util.List;
+
 import org.depromeet.sambad.moring.file.domain.FileEntity;
 import org.depromeet.sambad.moring.file.domain.FileRepository;
 import org.depromeet.sambad.moring.file.presentation.exception.NotFoundFileException;
@@ -31,5 +33,10 @@ public class FileRepositoryImpl implements FileRepository {
 	public FileEntity findById(Long id) {
 		return fileJpaRepository.findById(id)
 			.orElseThrow(NotFoundFileException::new);
+	}
+
+	@Override
+	public List<FileEntity> findAllByIsDefaultTrue() {
+		return fileJpaRepository.findAllByIsDefaultTrue();
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMember.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMember.java
@@ -50,7 +50,7 @@ public class MeetingMember extends BaseTimeEntity implements Comparable<MeetingM
 	@JoinColumn(name = "user_id")
 	private User user;
 
-	@OneToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "profile_image_file_id")
 	private FileEntity profileImageFile;
 

--- a/src/main/java/org/depromeet/sambad/moring/question/domain/Question.java
+++ b/src/main/java/org/depromeet/sambad/moring/question/domain/Question.java
@@ -16,6 +16,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
@@ -32,7 +33,7 @@ public class Question extends BaseTimeEntity {
 	@Column(name = "question_id")
 	private Long id;
 
-	@OneToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "question_image_file_id")
 	private FileEntity questionImageFile;
 

--- a/src/main/java/org/depromeet/sambad/moring/user/domain/User.java
+++ b/src/main/java/org/depromeet/sambad/moring/user/domain/User.java
@@ -19,6 +19,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
@@ -36,7 +37,7 @@ public class User extends BaseTimeEntity {
 	private Long id;
 
 	@JoinColumn(name = "profile_image_file_id")
-	@OneToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.LAZY)
 	private FileEntity profileImageFile;
 
 	private String name;


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- 카카오로부터 프로필 이미지를 받지 못한 경우, 준비해둔 기본 이미지로 프로필 이미지를 세팅합니다.
- FIle 관련 연관 관계를 ManyToOne으로 변경합니다.

## 🔗 ISSUE 링크
- resolved [SAMBAD-160](https://www.notion.so/depromeet/5dff1e9317d04c1cbaac8ea88d3ff2d6?pvs=4)