### PR TITLE
[SAMBAD-163] 파일 URL이 CDN URL을 포함한 Full URL로 제공되도록 변경

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/common/config/JacksonConfig.java
+++ b/src/main/java/org/depromeet/sambad/moring/common/config/JacksonConfig.java
@@ -1,0 +1,17 @@
+package org.depromeet.sambad.moring.common.config;
+
+import org.depromeet.sambad.moring.file.presentation.annotation.FullFileUrlAnnotationIntrospector;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+	@Bean
+	public Jackson2ObjectMapperBuilderCustomizer customizer(
+		FullFileUrlAnnotationIntrospector fullFileUrlAnnotationIntrospector
+	) {
+		return builder -> builder.annotationIntrospector(fullFileUrlAnnotationIntrospector);
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moring/file/application/FileService.java
+++ b/src/main/java/org/depromeet/sambad/moring/file/application/FileService.java
@@ -24,7 +24,7 @@ public class FileService {
 		String url = fileUploader.upload(multipartFile, multipartFile.getOriginalFilename());
 		FileEntity fileEntity = FileEntity.of(multipartFile.getOriginalFilename(), url);
 		fileRepository.save(fileEntity);
-		return FileUrlResponse.of(url);
+		return FileUrlResponse.of(fileEntity.getPhysicalPath());
 	}
 
 	@Transactional

--- a/src/main/java/org/depromeet/sambad/moring/file/infrastructure/FileProperties.java
+++ b/src/main/java/org/depromeet/sambad/moring/file/infrastructure/FileProperties.java
@@ -4,6 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "file")
 public record FileProperties(
-	String uploadPath
+	String uploadPath,
+	String baseUrl
 ) {
 }

--- a/src/main/java/org/depromeet/sambad/moring/file/presentation/annotation/FullFileUrl.java
+++ b/src/main/java/org/depromeet/sambad/moring/file/presentation/annotation/FullFileUrl.java
@@ -1,0 +1,20 @@
+package org.depromeet.sambad.moring.file.presentation.annotation;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * 필드에 해당 어노테이션을 부착할 시, 해당 필드의 값을 전체 파일 URL로 변환하여 반환합니다.<br />
+ * e.g., "/path/to/file" -> "http://example.com/path/to/file"
+ *
+ * @see FullFileUrlSerializer
+ * @see FullFileUrlAnnotationIntrospector
+ * @see org.depromeet.sambad.moring.common.config.JacksonConfig
+ */
+@Target({FIELD, METHOD, PARAMETER, TYPE, ANNOTATION_TYPE})
+@Retention(RUNTIME)
+public @interface FullFileUrl {
+}

--- a/src/main/java/org/depromeet/sambad/moring/file/presentation/annotation/FullFileUrlAnnotationIntrospector.java
+++ b/src/main/java/org/depromeet/sambad/moring/file/presentation/annotation/FullFileUrlAnnotationIntrospector.java
@@ -1,0 +1,25 @@
+package org.depromeet.sambad.moring.file.presentation.annotation;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class FullFileUrlAnnotationIntrospector extends JacksonAnnotationIntrospector {
+
+	private final FullFileUrlSerializer fullFileUrlSerializer;
+
+	@Override
+	public JsonSerializer<?> findSerializer(Annotated am) {
+		if (am.hasAnnotation(FullFileUrl.class)) {
+			return fullFileUrlSerializer;
+		}
+		return (JsonSerializer<?>)super.findSerializer(am);
+	}
+}
+

--- a/src/main/java/org/depromeet/sambad/moring/file/presentation/annotation/FullFileUrlSerializer.java
+++ b/src/main/java/org/depromeet/sambad/moring/file/presentation/annotation/FullFileUrlSerializer.java
@@ -1,0 +1,49 @@
+package org.depromeet.sambad.moring.file.presentation.annotation;
+
+import static java.lang.String.*;
+
+import java.io.IOException;
+
+import org.depromeet.sambad.moring.file.infrastructure.FileProperties;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class FullFileUrlSerializer extends JsonSerializer<String> {
+
+	private final FileProperties fileProperties;
+
+	@Override
+	public void serialize(String value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+		if (value == null) {
+			gen.writeNull();
+			return;
+		}
+
+		String fullUrl = format("%s/%s", fileProperties.baseUrl(), normalizePath(value));
+		gen.writeString(fullUrl);
+	}
+
+	private String normalizePath(String value) {
+		if (value.startsWith(".")) {
+			value = value.substring(1);
+		}
+
+		if (value.startsWith("/")) {
+			value = value.substring(1);
+		}
+
+		if (value.endsWith("/")) {
+			value = value.substring(0, value.length() - 1);
+		}
+
+		return value;
+	}
+}
+

--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/application/MeetingService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/application/MeetingService.java
@@ -30,7 +30,9 @@ public class MeetingService {
 		Meeting meeting = generateMeeting(request);
 		addTypesToMeeting(request, meeting);
 
-		meetingQuestionService.createActiveQuestion(meeting, meeting.getOwner(), null);
+		// NOTE: 모임 생성 시점엔 아직 모임장도 모임원 가입이 안된 상태이므로, 오류 발생
+		// 해당 로직 추가한 이유가 궁금합니다.
+		// meetingQuestionService.createActiveQuestion(meeting, meeting.getOwner(), null);
 		return meeting;
 	}
 

--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/request/MeetingPersistRequest.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/request/MeetingPersistRequest.java
@@ -16,7 +16,7 @@ public record MeetingPersistRequest(
 	@Size(min = 2, max = 10)
 	String name,
 
-	@Schema(description = "모임 유형의 ID 목록", example = "[1,3,5]", requiredMode = REQUIRED)
+	@Schema(description = "모임 유형의 ID 목록", example = "[1,3]", requiredMode = REQUIRED)
 	@NotNull
 	@Size(max = 2)
 	List<Long> typeIds

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/MeetingMemberController.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/MeetingMemberController.java
@@ -31,7 +31,7 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "모임원", description = "모임 멤버 관련 api / 담당자 : 권기준")
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/v1/meetings/{meetingId}/members")
+@RequestMapping("/v1/meetings")
 public class MeetingMemberController {
 
 	private final MeetingMemberService meetingMemberService;
@@ -42,7 +42,7 @@ public class MeetingMemberController {
 		@ApiResponse(responseCode = "403", description = "USER_NOT_MEMBER_OF_MEETING"),
 		@ApiResponse(responseCode = "404", description = "MEETING_MEMBER_NOT_FOUND")
 	})
-	@GetMapping("/{memberId}")
+	@GetMapping("/{meetingId}/members/{memberId}")
 	public ResponseEntity<MeetingMemberResponse> getMeetingMember(
 		@UserId Long userId,
 		@Parameter(description = "모임 ID", example = "1", required = true) @PathVariable("meetingId") Long meetingId,
@@ -52,13 +52,13 @@ public class MeetingMemberController {
 		return ResponseEntity.ok(response);
 	}
 
-	@Operation(summary = "모임원 정보 조회", description = "특정 모임의 특정 모임원을 조회합니다.")
+	@Operation(summary = "자기 자신 모임원 정보 조회", description = "자기 자신의 모임원 정보를 조회합니다.")
 	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "모임원 조회 성공"),
+		@ApiResponse(responseCode = "200", description = "정보 조회 성공"),
 		@ApiResponse(responseCode = "403", description = "USER_NOT_MEMBER_OF_MEETING"),
 		@ApiResponse(responseCode = "404", description = "MEETING_MEMBER_NOT_FOUND")
 	})
-	@GetMapping("/me")
+	@GetMapping("/{meetingId}/members/me")
 	public ResponseEntity<MeetingMemberResponse> getMyMeetingMember(
 		@UserId Long userId,
 		@Parameter(description = "모임 ID", example = "1", required = true) @PathVariable("meetingId") Long meetingId
@@ -72,7 +72,7 @@ public class MeetingMemberController {
 		@ApiResponse(responseCode = "200", description = "모임원 목록 조회 성공"),
 		@ApiResponse(responseCode = "403", description = "USER_NOT_MEMBER_OF_MEETING")
 	})
-	@GetMapping
+	@GetMapping("/{meetingId}/members")
 	public ResponseEntity<MeetingMemberListResponse> getMeetingMembers(
 		@UserId Long userId,
 		@Parameter(description = "모임 ID", example = "1", required = true) @PathVariable("meetingId") Long meetingId
@@ -88,7 +88,7 @@ public class MeetingMemberController {
 		@ApiResponse(responseCode = "404", description = "MEETING_NOT_FOUND / USER_NOT_FOUND"),
 		@ApiResponse(responseCode = "409", description = "MEETING_MEMBER_ALREADY_EXISTS")
 	})
-	@PostMapping
+	@PostMapping("/members")
 	public ResponseEntity<MeetingMemberPersistResponse> createMeetingMember(
 		@UserId Long userId,
 		@Parameter(description = "모임의 고유 초대 코드", example = "A1G05C", required = true) @RequestParam("code") String code,
@@ -104,7 +104,7 @@ public class MeetingMemberController {
 		@ApiResponse(responseCode = "403", description = "USER_NOT_MEMBER_OF_MEETING"),
 		@ApiResponse(responseCode = "404", description = "NO_MEETING_MEMBER_IN_CONDITION")
 	})
-	@GetMapping("/questions/target")
+	@GetMapping("/{meetingId}/members/questions/target")
 	public ResponseEntity<MeetingMemberListResponseDetail> getRandomQuestionMember(
 		@UserId Long userId,
 		@Parameter(description = "모임 ID", example = "1", required = true) @PathVariable("meetingId") Long meetingId,

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/request/MeetingMemberPersistRequest.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/request/MeetingMemberPersistRequest.java
@@ -18,7 +18,7 @@ import jakarta.validation.constraints.Size;
 
 public record MeetingMemberPersistRequest(
 
-	@Schema(description = "모임원 유형 (HOST, MEMBER)", example = "HOST", requiredMode = REQUIRED)
+	@Schema(description = "모임원 유형 (OWNER, ADMIN, MEMBER)", example = "OWNER", requiredMode = REQUIRED)
 	@NotNull
 	MeetingMemberRole role,
 

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/response/MeetingMemberListResponseDetail.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/response/MeetingMemberListResponseDetail.java
@@ -2,6 +2,7 @@ package org.depromeet.sambad.moring.meeting.member.presentation.response;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
 
+import org.depromeet.sambad.moring.file.presentation.annotation.FullFileUrl;
 import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
 import org.depromeet.sambad.moring.meeting.member.domain.MeetingMemberRole;
 
@@ -10,10 +11,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record MeetingMemberListResponseDetail(
 	@Schema(description = "모임원 ID", example = "1", requiredMode = REQUIRED)
 	Long meetingMemberId,
+
 	@Schema(description = "모임원 이름", example = "이한음", requiredMode = REQUIRED)
 	String name,
+
+	@FullFileUrl
 	@Schema(description = "모임원 프로필 이미지 URL", example = "https://example.com", requiredMode = REQUIRED)
 	String profileImageFileUrl,
+
 	@Schema(description = "모임원 역할", example = "OWNER", requiredMode = REQUIRED)
 	MeetingMemberRole role
 ) {

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/response/MeetingMemberResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/response/MeetingMemberResponse.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import org.depromeet.sambad.moring.common.domain.Gender;
+import org.depromeet.sambad.moring.file.presentation.annotation.FullFileUrl;
 import org.depromeet.sambad.moring.meeting.member.domain.MBTI;
 import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
 import org.depromeet.sambad.moring.meeting.member.domain.MeetingMemberRole;
@@ -19,6 +20,7 @@ public record MeetingMemberResponse(
 	@Schema(description = "모임원 이름", example = "이한음", requiredMode = REQUIRED)
 	String name,
 
+	@FullFileUrl
 	@Schema(description = "모임원 프로필 이미지 URL", example = "https://example.com", requiredMode = REQUIRED)
 	String profileImageFileUrl,
 

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/response/ActiveMeetingQuestionResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/response/ActiveMeetingQuestionResponse.java
@@ -1,6 +1,7 @@
 package org.depromeet.sambad.moring.meeting.question.presentation.response;
 
 import org.depromeet.sambad.moring.common.response.DateFormatter;
+import org.depromeet.sambad.moring.file.presentation.annotation.FullFileUrl;
 import org.depromeet.sambad.moring.meeting.meeting.domain.Meeting;
 import org.depromeet.sambad.moring.meeting.member.presentation.response.MeetingMemberListResponseDetail;
 import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
@@ -12,24 +13,35 @@ import lombok.Builder;
 public record ActiveMeetingQuestionResponse(
 	@Schema(example = "1", description = "모임 질문 식별자")
 	Long meetingQuestionId,
+
+	@FullFileUrl
 	@Schema(example = "https://avatars.githubusercontent.com/u/173370739?v=4", description = "모임 질문 이미지 URL")
 	String questionImageFileUrl,
+
 	@Schema(example = "갖고 싶은 초능력은?", description = "모임 질문 TITLE")
 	String title,
+
 	@Schema(example = "18", description = "모임 내 질문 인덱스로 1 부터 시작합니다.")
 	int questionNumber,
+
 	@Schema(example = "15", description = "전체 모임원 수")
 	int totalMeetingMemberCount,
+
 	@Schema(example = "9", description = "응답한 모임원 수")
 	int responseCount,
+
 	@Schema(example = "70", description = "참여율, 소수점 첫째 자리에서 반올림하여 반환합니다.")
 	double engagementRate,
+
 	@Schema(example = "yyyy-MM-dd HH:mm:ss", description = "릴레이 질문 시작 시간")
 	String startTime,
+
 	@Schema(example = "false", description = "로그인한 유저의 답변 유무")
 	Boolean isAnswered,
+
 	@Schema(example = "true", description = "질문인의 질문 등록 여부")
 	Boolean isQuestionRegistered,
+
 	@Schema(description = "질문인에 대한 정보")
 	MeetingMemberListResponseDetail targetMember
 ) {

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/response/FullInactiveMeetingQuestionListResponseDetail.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/response/FullInactiveMeetingQuestionListResponseDetail.java
@@ -3,6 +3,7 @@ package org.depromeet.sambad.moring.meeting.question.presentation.response;
 import java.util.List;
 
 import org.depromeet.sambad.moring.common.response.DateFormatter;
+import org.depromeet.sambad.moring.file.presentation.annotation.FullFileUrl;
 import org.depromeet.sambad.moring.meeting.meeting.domain.Meeting;
 import org.depromeet.sambad.moring.meeting.member.presentation.response.MeetingMemberListResponseDetail;
 import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
@@ -14,6 +15,7 @@ import lombok.Builder;
 public record FullInactiveMeetingQuestionListResponseDetail(
 	@Schema(example = "1", description = "모임 질문 식별자")
 	Long meetingQuestionId,
+	@FullFileUrl
 	@Schema(example = "https://avatars.githubusercontent.com/u/173370739?v=4", description = "모임 질문 이미지 URL")
 	String questionImageFileUrl,
 	@Schema(example = "갖고 싶은 초능력은?", description = "모임 질문 TITLE")

--- a/src/main/java/org/depromeet/sambad/moring/question/presentation/response/QuestionResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/question/presentation/response/QuestionResponse.java
@@ -2,11 +2,13 @@ package org.depromeet.sambad.moring.question.presentation.response;
 
 import java.util.List;
 
+import org.depromeet.sambad.moring.file.presentation.annotation.FullFileUrl;
 import org.depromeet.sambad.moring.meeting.answer.presentation.response.AnswerResponse;
 import org.depromeet.sambad.moring.question.domain.Question;
 
 public record QuestionResponse(
 	Long questionId,
+	@FullFileUrl
 	String questionImageFileUrl,
 	String title,
 	List<AnswerResponse> answers

--- a/src/main/java/org/depromeet/sambad/moring/user/presentation/response/UserResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/user/presentation/response/UserResponse.java
@@ -4,6 +4,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
 
 import java.time.LocalDateTime;
 
+import org.depromeet.sambad.moring.file.presentation.annotation.FullFileUrl;
 import org.depromeet.sambad.moring.user.domain.User;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -15,6 +16,7 @@ public record UserResponse(
 	@Schema(description = "유저 이메일", example = "example@abc.com", requiredMode = REQUIRED)
 	String email,
 
+	@FullFileUrl
 	@Schema(description = "프로필 이미지 경로", example = "https://example.com/profile.jpg", requiredMode = REQUIRED)
 	String profileImageFileUrl,
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -2,3 +2,7 @@ sentry:
   dsn: ${SENTRY_DSN}
   environment: dev
   release: "moring-dev@1.0.0"
+
+file:
+  upload-path: uploaded
+  base-url: https://file.moring.one

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,7 +4,8 @@ spring:
       ddl-auto: update
 
 file:
-  upload-path: ./temp
+  upload-path: temp
+  base-url: http://localhost:8080
 
 sentry:
   enabled: false

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -13,3 +13,7 @@ decorator:
   datasource:
     p6spy:
       enable-logging: false
+
+file:
+  upload-path: uploaded
+  base-url: https://file.moring.one


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- `@FullFileUrl` 어노테이션 부착 시, Path 앞에 Base URL (e.g., `https://file.moring.one`)이 부착되어 응답으로 제공되는 기능을 구현합니다.
  - Base URL은 환경에 따라 바뀌며, 도메인에 따라 바뀌므로 가변성을 염두하여 property로 빼야 합니다.
  - Entity에선 Property를 가져오지 못하기 때문에 경로 제공 시 Base URL을 붙이기 어렵습니다.
  - 그렇다고 도메인 내에 존재하는 메서드에 Base URL을 전파해주자니 파라미터를 전달해야 하는 뎁스가 너무 깊습니다.
  - 따라서, 관심사를 분리하여 Base URL의 부착 여부는 비즈니스 로직 내에서는 신경쓰지 않아도 되도록 구현했습니다.
- 파일은 저장 시, 물리 파일명으로 저장되어야 하며, 정해진 directory에 저장되어야 합니다.
  - `ObjectStorageUploader` 내 논리 파일명으로 저장되던 점, directory 없이 root에 저장되던 점을 수정합니다.

## 💡 코드 리뷰 시 참고 사항
- 스프링 기본 제공 `ObjectMapper`를 그대로 사용하며 커스텀할 부분만 추가하는 방법, `AnnotationIntrospector`의 존재 등 다양한 기술을 알아볼 수 있어 좋았습니다 🎶

## 🔗 ISSUE 링크
- resolved [SAMBAD-163](https://www.notion.so/depromeet/Full-URL-be08423b84dd4479b07a6e322b0c89d6?pvs=4)