### PR TITLE
[SAMBAD-166] `refresh_token` 추가

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/auth/application/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/application/OAuth2LoginSuccessHandler.java
@@ -1,20 +1,17 @@
 package org.depromeet.sambad.moring.auth.application;
 
 import static org.depromeet.sambad.moring.auth.presentation.exception.AuthExceptionCode.*;
-import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.*;
 
 import java.io.IOException;
 
 import org.depromeet.sambad.moring.auth.domain.CustomOAuth2User;
 import org.depromeet.sambad.moring.auth.domain.LoginResult;
 import org.depromeet.sambad.moring.auth.infrastructure.SecurityProperties;
-import org.depromeet.sambad.moring.auth.infrastructure.TokenProperties;
 import org.depromeet.sambad.moring.auth.presentation.exception.AlreadyRegisteredUserException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +21,8 @@ import lombok.RequiredArgsConstructor;
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
 	private final AuthService authService;
-	private final TokenProperties tokenProperties;
+	private final TokenInjector tokenInjector;
+
 	private final SecurityProperties securityProperties;
 
 	@Override
@@ -33,7 +31,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 	) throws IOException {
 		try {
 			LoginResult result = resolveLoginResultFromAuthentication(authentication);
-			injectTokenToCookie(result, response);
+			tokenInjector.injectTokensToCookie(result, response);
 			redirectToSuccessUrl(result, response);
 		} catch (AlreadyRegisteredUserException e) {
 			handleAlreadyExistUser(response);
@@ -43,19 +41,6 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 	private LoginResult resolveLoginResultFromAuthentication(Authentication authentication) {
 		CustomOAuth2User oAuth2User = (CustomOAuth2User)authentication.getPrincipal();
 		return authService.handleLoginSuccess(oAuth2User.getAuthAttributes());
-	}
-
-	private void injectTokenToCookie(LoginResult result, HttpServletResponse response) throws IOException {
-		int expirationSeconds = (int)(tokenProperties.expirationTimeMs() / 1000);
-
-		Cookie cookie = new Cookie(ACCESS_TOKEN, result.accessToken());
-		cookie.setPath("/");
-		cookie.setMaxAge(expirationSeconds);
-		cookie.setHttpOnly(true);
-		cookie.setDomain(securityProperties.subDomain());
-		cookie.setSecure(true);
-
-		response.addCookie(cookie);
 	}
 
 	private void redirectToSuccessUrl(LoginResult result, HttpServletResponse response) throws IOException {

--- a/src/main/java/org/depromeet/sambad/moring/auth/application/OAuth2UserService.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/application/OAuth2UserService.java
@@ -20,8 +20,8 @@ public class OAuth2UserService extends DefaultOAuth2UserService {
 	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 		OAuth2User oAuth2User = super.loadUser(userRequest);
 
-		List<GrantedAuthority> authorities = AuthorityUtils.createAuthorityList(
-			"ROLE_USER"); // TODO: Implement role management
+		// TODO: Implement role management
+		List<GrantedAuthority> authorities = AuthorityUtils.createAuthorityList("ROLE_USER");
 
 		ClientRegistration clientRegistration = userRequest.getClientRegistration();
 		String registrationId = clientRegistration.getRegistrationId();

--- a/src/main/java/org/depromeet/sambad/moring/auth/application/RefreshTokenRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/application/RefreshTokenRepository.java
@@ -1,0 +1,14 @@
+package org.depromeet.sambad.moring.auth.application;
+
+import java.util.Optional;
+
+import org.depromeet.sambad.moring.auth.domain.RefreshToken;
+
+public interface RefreshTokenRepository {
+
+	Optional<RefreshToken> findByToken(String token);
+
+	void save(RefreshToken refreshToken);
+
+	Optional<RefreshToken> findByUserId(Long id);
+}

--- a/src/main/java/org/depromeet/sambad/moring/auth/application/RefreshTokenService.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/application/RefreshTokenService.java
@@ -1,0 +1,68 @@
+package org.depromeet.sambad.moring.auth.application;
+
+import org.depromeet.sambad.moring.auth.domain.LoginResult;
+import org.depromeet.sambad.moring.auth.domain.RefreshToken;
+import org.depromeet.sambad.moring.auth.domain.TokenGenerator;
+import org.depromeet.sambad.moring.auth.domain.TokenResolver;
+import org.depromeet.sambad.moring.auth.presentation.exception.AuthenticationRequiredException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class RefreshTokenService {
+
+	private final RefreshTokenRepository refreshTokenRepository;
+	private final TokenGenerator tokenGenerator;
+	private final TokenResolver tokenResolver;
+	private final TokenInjector tokenInjector;
+
+	@Transactional
+	public LoginResult reissueBasedOnRefreshToken(HttpServletRequest request, HttpServletResponse response) {
+		String refreshToken = tokenResolver.resolveRefreshTokenFromRequest(request)
+			.orElseThrow(AuthenticationRequiredException::new);
+
+		RefreshToken savedRefreshToken = validateAndGetSavedRefreshToken(refreshToken);
+
+		return getReissuedTokenResult(response, savedRefreshToken);
+	}
+
+	private LoginResult getReissuedTokenResult(HttpServletResponse response, RefreshToken savedRefreshToken) {
+		String rotatedRefreshToken = this.rotate(savedRefreshToken);
+		String reissuedAccessToken = tokenGenerator.generateAccessToken(savedRefreshToken.getUserId());
+
+		LoginResult loginResult = new LoginResult(reissuedAccessToken, rotatedRefreshToken, false);
+
+		tokenInjector.injectTokensToCookie(loginResult, response);
+
+		return loginResult;
+	}
+
+	private RefreshToken validateAndGetSavedRefreshToken(String refreshToken) {
+		Long userId = Long.valueOf(tokenResolver.getSubjectFromToken(refreshToken));
+		RefreshToken savedRefreshToken = this.getByTokenString(refreshToken);
+
+		savedRefreshToken.validateWith(refreshToken, userId);
+
+		return savedRefreshToken;
+	}
+
+	public RefreshToken getByTokenString(String token) {
+		return refreshTokenRepository.findByToken(token)
+			.orElseThrow(AuthenticationRequiredException::new);
+	}
+
+	private String rotate(RefreshToken refreshToken) {
+		String reissuedToken = tokenGenerator.generateRefreshToken(refreshToken.getUserId());
+		refreshToken.rotate(reissuedToken);
+		refreshTokenRepository.save(refreshToken);
+
+		return reissuedToken;
+	}
+}
+

--- a/src/main/java/org/depromeet/sambad/moring/auth/application/TokenInjector.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/application/TokenInjector.java
@@ -34,6 +34,7 @@ public class TokenInjector {
 		cookie.setHttpOnly(securityProperties.cookie().httpOnly());
 		cookie.setDomain(securityProperties.cookie().domain());
 		cookie.setSecure(securityProperties.cookie().secure());
+		cookie.setAttribute("SameSite", "None");
 
 		response.addCookie(cookie);
 	}

--- a/src/main/java/org/depromeet/sambad/moring/auth/application/TokenInjector.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/application/TokenInjector.java
@@ -1,0 +1,40 @@
+package org.depromeet.sambad.moring.auth.application;
+
+import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.*;
+
+import org.depromeet.sambad.moring.auth.domain.LoginResult;
+import org.depromeet.sambad.moring.auth.infrastructure.SecurityProperties;
+import org.depromeet.sambad.moring.auth.infrastructure.TokenProperties;
+import org.springframework.stereotype.Service;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class TokenInjector {
+
+	private final TokenProperties tokenProperties;
+	private final SecurityProperties securityProperties;
+
+	public void injectTokensToCookie(LoginResult result, HttpServletResponse response) {
+		// Add 5 seconds to the expiration time to prevent the token from being deleted before the expiration time.
+		int accessTokenMaxAge = (int)tokenProperties.expirationTime().accessToken() + 5;
+		int refreshTokenMaxAge = (int)tokenProperties.expirationTime().refreshToken() + 5;
+
+		addCookie(ACCESS_TOKEN, result.accessToken(), accessTokenMaxAge, response);
+		addCookie(REFRESH_TOKEN, result.refreshToken(), refreshTokenMaxAge, response);
+	}
+
+	private void addCookie(String name, String value, int maxAge, HttpServletResponse response) {
+		Cookie cookie = new Cookie(name, value);
+		cookie.setPath("/");
+		cookie.setMaxAge(maxAge);
+		cookie.setHttpOnly(securityProperties.cookie().httpOnly());
+		cookie.setDomain(securityProperties.cookie().domain());
+		cookie.setSecure(securityProperties.cookie().secure());
+
+		response.addCookie(cookie);
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moring/auth/domain/LoginResult.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/domain/LoginResult.java
@@ -2,6 +2,7 @@ package org.depromeet.sambad.moring.auth.domain;
 
 public record LoginResult(
 	String accessToken,
+	String refreshToken,
 	boolean isNewUser
 ) {
 }

--- a/src/main/java/org/depromeet/sambad/moring/auth/domain/RefreshToken.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/domain/RefreshToken.java
@@ -48,6 +48,12 @@ public class RefreshToken extends BaseTimeEntity {
 		this.token = token;
 	}
 
+	public void updateExpirationIfExpired(long expiredSeconds) {
+		if (expiredAt.isBefore(LocalDateTime.now())) {
+			expiredAt = LocalDateTime.now().plusSeconds(expiredSeconds);
+		}
+	}
+
 	public void validateWith(String token, Long userId) {
 		if (isNotMatchedToken(token) || isExpired() || isNotMatchedUserId(userId)) {
 			throw new RefreshTokenNotValidaException();

--- a/src/main/java/org/depromeet/sambad/moring/auth/domain/RefreshToken.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/domain/RefreshToken.java
@@ -1,0 +1,68 @@
+package org.depromeet.sambad.moring.auth.domain;
+
+import static lombok.AccessLevel.*;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+import org.depromeet.sambad.moring.auth.presentation.exception.RefreshTokenNotValidaException;
+import org.depromeet.sambad.moring.common.domain.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class RefreshToken extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "refresh_token_id")
+	private Long id;
+
+	private Long userId;
+
+	private String token;
+
+	private LocalDateTime expiredAt;
+
+	private RefreshToken(Long userId, String token, LocalDateTime expiredAt) {
+		this.userId = userId;
+		this.token = token;
+		this.expiredAt = expiredAt;
+	}
+
+	public static RefreshToken of(Long userId, String token, long expiredSeconds) {
+		LocalDateTime expiredAt = LocalDateTime.now().plusSeconds(expiredSeconds);
+
+		return new RefreshToken(userId, token, expiredAt);
+	}
+
+	public void rotate(String token) {
+		this.token = token;
+	}
+
+	public void validateWith(String token, Long userId) {
+		if (isNotMatchedToken(token) || isExpired() || isNotMatchedUserId(userId)) {
+			throw new RefreshTokenNotValidaException();
+		}
+	}
+
+	private boolean isNotMatchedToken(String token) {
+		return !Objects.equals(this.token, token);
+	}
+
+	private boolean isExpired() {
+		return expiredAt.isBefore(LocalDateTime.now());
+	}
+
+	private boolean isNotMatchedUserId(Long userId) {
+		return !Objects.equals(this.userId, userId);
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moring/auth/domain/TokenGenerator.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/domain/TokenGenerator.java
@@ -2,5 +2,7 @@ package org.depromeet.sambad.moring.auth.domain;
 
 public interface TokenGenerator {
 
-	String generate(Long userId);
+	String generateAccessToken(Long userId);
+
+	String generateRefreshToken(Long userId);
 }

--- a/src/main/java/org/depromeet/sambad/moring/auth/domain/TokenResolver.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/domain/TokenResolver.java
@@ -8,5 +8,7 @@ public interface TokenResolver {
 
 	Optional<String> resolveTokenFromRequest(HttpServletRequest request);
 
+	Optional<String> resolveRefreshTokenFromRequest(HttpServletRequest request);
+
 	String getSubjectFromToken(String token);
 }

--- a/src/main/java/org/depromeet/sambad/moring/auth/infrastructure/JwtTokenGenerator.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/infrastructure/JwtTokenGenerator.java
@@ -19,16 +19,30 @@ public class JwtTokenGenerator implements TokenGenerator {
 
 	private final TokenProperties tokenProperties;
 
-	public String generate(Long userId) {
+	@Override
+	public String generateAccessToken(Long userId) {
 		long currentTimeMillis = System.currentTimeMillis();
 		Date now = new Date(currentTimeMillis);
-		Date expiration = new Date(currentTimeMillis + tokenProperties.expirationTimeMs());
+		Date expiration = new Date(currentTimeMillis + tokenProperties.expirationTime().accessToken() * 1000);
 		SecretKey secretKey = Keys.hmacShaKeyFor(BASE64.decode(tokenProperties.secretKey()));
 
 		return Jwts.builder()
 			.subject(String.valueOf(userId))
 			.issuedAt(now)
 			.expiration(expiration)
+			.signWith(secretKey)
+			.compact();
+	}
+
+	@Override
+	public String generateRefreshToken(Long userId) {
+		long currentTimeMillis = System.currentTimeMillis();
+		Date now = new Date(currentTimeMillis);
+		SecretKey secretKey = Keys.hmacShaKeyFor(BASE64.decode(tokenProperties.secretKey()));
+
+		return Jwts.builder()
+			.subject(String.valueOf(userId))
+			.issuedAt(now)
 			.signWith(secretKey)
 			.compact();
 	}

--- a/src/main/java/org/depromeet/sambad/moring/auth/infrastructure/RefreshTokenJpaRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/infrastructure/RefreshTokenJpaRepository.java
@@ -1,0 +1,13 @@
+package org.depromeet.sambad.moring.auth.infrastructure;
+
+import java.util.Optional;
+
+import org.depromeet.sambad.moring.auth.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenJpaRepository extends JpaRepository<RefreshToken, Long> {
+
+	Optional<RefreshToken> findByToken(String token);
+
+	Optional<RefreshToken> findFirstByUserIdOrderByIdDesc(Long id);
+}

--- a/src/main/java/org/depromeet/sambad/moring/auth/infrastructure/RefreshTokenRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/infrastructure/RefreshTokenRepositoryImpl.java
@@ -1,0 +1,31 @@
+package org.depromeet.sambad.moring.auth.infrastructure;
+
+import java.util.Optional;
+
+import org.depromeet.sambad.moring.auth.application.RefreshTokenRepository;
+import org.depromeet.sambad.moring.auth.domain.RefreshToken;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Repository
+public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
+
+	private final RefreshTokenJpaRepository refreshTokenJpaRepository;
+
+	@Override
+	public Optional<RefreshToken> findByToken(String token) {
+		return refreshTokenJpaRepository.findByToken(token);
+	}
+
+	@Override
+	public Optional<RefreshToken> findByUserId(Long id) {
+		return refreshTokenJpaRepository.findFirstByUserIdOrderByIdDesc(id);
+	}
+
+	@Override
+	public void save(RefreshToken refreshToken) {
+		refreshTokenJpaRepository.save(refreshToken);
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moring/auth/infrastructure/SecurityProperties.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/infrastructure/SecurityProperties.java
@@ -1,11 +1,19 @@
 package org.depromeet.sambad.moring.auth.infrastructure;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 @ConfigurationProperties(prefix = "spring.security")
 public record SecurityProperties(
-	String subDomain,
 	String loginUrl,
-	String redirectUrl
+	String redirectUrl,
+	@NestedConfigurationProperty
+	Cookie cookie
 ) {
+	public record Cookie(
+		String domain,
+		boolean httpOnly,
+		boolean secure
+	) {
+	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/auth/infrastructure/TokenProperties.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/infrastructure/TokenProperties.java
@@ -1,6 +1,7 @@
 package org.depromeet.sambad.moring.auth.infrastructure;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -8,6 +9,13 @@ import jakarta.validation.constraints.NotNull;
 @ConfigurationProperties(prefix = "jwt")
 public record TokenProperties(
 	@NotNull String secretKey,
-	@Min(0) long expirationTimeMs
+	@NestedConfigurationProperty
+	@NotNull ExpirationTime expirationTime
 ) {
+
+	public record ExpirationTime(
+		@Min(0) long accessToken,
+		@Min(0) long refreshToken
+	) {
+	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/auth/presentation/JwtTokenFilter.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/presentation/JwtTokenFilter.java
@@ -47,7 +47,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
 			String token = resolveTokenFromRequest(request, response);
 			setAuthentication(request, getUserDetails(token, request, response));
 		} catch (ExpiredJwtException | AuthenticationRequiredException e) {
-			log.warn("Failed to authenticate", e);
+			log.debug("Failed to authenticate", e);
 			invalidateCookie(ACCESS_TOKEN, response);
 		} catch (RefreshTokenNotValidaException e) {
 			log.warn("Failed to authenticate", e);

--- a/src/main/java/org/depromeet/sambad/moring/auth/presentation/exception/AuthExceptionCode.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/presentation/exception/AuthExceptionCode.java
@@ -14,6 +14,8 @@ public enum AuthExceptionCode implements ExceptionCode {
 	ALREADY_REGISTERED_USER(BAD_REQUEST, "다른 소셜 계정으로 이미 가입된 사용자입니다."),
 
 	AUTHENTICATION_REQUIRED(UNAUTHORIZED, "인증 정보가 유효하지 않습니다."),
+
+	REFRESH_TOKEN_NOT_VALID(UNAUTHORIZED, "리프레시 토큰이 유효하지 않습니다."),
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/org/depromeet/sambad/moring/auth/presentation/exception/RefreshTokenNotValidaException.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/presentation/exception/RefreshTokenNotValidaException.java
@@ -1,0 +1,11 @@
+package org.depromeet.sambad.moring.auth.presentation.exception;
+
+import static org.depromeet.sambad.moring.auth.presentation.exception.AuthExceptionCode.*;
+
+import org.depromeet.sambad.moring.common.exception.BusinessException;
+
+public class RefreshTokenNotValidaException extends BusinessException {
+	public RefreshTokenNotValidaException() {
+		super(REFRESH_TOKEN_NOT_VALID);
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,9 +26,12 @@ spring:
       max-request-size: ${MAX_REQUEST_SIZE:5MB}
       enabled: true
   security:
-    sub-domain: ${SUB_DOMAIN:moring.one}
     login-url: ${LOGIN_URL:/login}
     redirect-url: ${REDIRECT_URL:/}
+    cookie:
+      domain: ${COOKIE_DOMAIN:moring.one}
+      secure: ${COOKIE_SECURE:true}
+      http-only: ${COOKIE_HTTP_ONLY:true}
     oauth2:
       client:
         provider:
@@ -69,7 +72,9 @@ decorator:
 
 jwt:
   secret-key: ${JWT_SECRET_KEY}
-  expiration-time-ms: ${JWT_EXPIRATION_TIME_MS:18000000}
+  expiration-time:
+    access-token: ${JWT_EXPIRATION_TIME_ACCESS_TOKEN:1800} # 30 minutes
+    refresh-token: ${JWT_EXPIRATION_TIME_REFRESH_TOKEN:7776000} # 90 days
 
 cloud:
   ncp:


### PR DESCRIPTION
### 📍 [SAMBAD-이슈번호] PR 제목


## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- `refresh_token`을 추가합니다.
- 만료는 90일 단위로 이루어지며, 리프레시 토큰이 추가됨에 따라 액세스 토큰의 만료 시간은 30분으로 줄어듭니다.
- 아래와 같은 플로우를 거쳐 액세스 토큰을 재발급합니다.
  1. 로그인 성공 시 `access_token`, `refresh_token` 발급
      1. 만약 유저의 `refresh_token`이 DB에 저장되어 있지 않다면, 새로 저장
  2. `access_token` 만료 시, `refresh_token` 확인
  3. 아직 만료되지 않았으며 유효한 `refresh_token`일 시, `access_token`을 재발급
      1. 이 때, `refresh_token` 또한 토큰 갱신 (refresh token rotation이라 칭하는 기법, 탈취 방어)
  5. `refresh_token`이 만료되었거나 없을 경우, 쿠키 내 토큰을 모두 invalidate

## 🔗 ISSUE 링크
- resolved [SAMBAD-166](https://www.notion.so/depromeet/Refresh-Token-11f7ffa495af4d109fcc7b359c8342b6?pvs=4)