### PR TITLE
[SAMBAD-177] 다음 릴레이 질문으로 업데이트 시나리오 추가

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/application/MeetingAnswerRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/application/MeetingAnswerRepository.java
@@ -10,13 +10,15 @@ public interface MeetingAnswerRepository {
 
 	void save(MeetingAnswer meetingAnswer);
 
+	boolean existsByMeetingMember(Long meetingQuestionId, Long meetingMemberId);
+
+	boolean isAllAnsweredByMeetingIdAndMeetingQuestionId(Long meetingId, Long meetingQuestionId);
+
 	List<MeetingAnswer> findMostSelected(Long meetingQuestionId);
 
 	List<MeetingAnswer> findByMeetingQuestionIdAndMeetingMemberId(Long meetingQuestionId, Long meetingMemberId);
 
 	List<MeetingMember> findMeetingMembersSelectWith(Long questionId, List<Long> answerIds);
-
-	boolean existsByMeetingMember(Long meetingQuestionId, Long meetingMemberId);
 
 	MyMeetingAnswerListResponse findAllByMeetingMemberId(Long meetingMemberId);
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/domain/MeetingAnswer.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/domain/MeetingAnswer.java
@@ -48,6 +48,8 @@ public class MeetingAnswer extends BaseTimeEntity {
 		this.meetingQuestion = meetingQuestion;
 		this.answer = answer;
 		this.meetingMember = meetingMember;
+
+		meetingQuestion.addMeetingAnswer(this);
 	}
 
 	public String getAnswerContent() {

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerQueryRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerQueryRepository.java
@@ -1,17 +1,25 @@
 package org.depromeet.sambad.moring.meeting.answer.infrastructure;
 
 import static com.querydsl.core.types.dsl.Expressions.*;
+import static com.querydsl.jpa.JPAExpressions.*;
 import static org.depromeet.sambad.moring.meeting.answer.domain.QMeetingAnswer.*;
+import static org.depromeet.sambad.moring.meeting.comment.domain.comment.QMeetingQuestionComment.*;
+import static org.depromeet.sambad.moring.meeting.member.domain.QMeetingMember.*;
 
 import java.util.List;
 import java.util.Objects;
 
 import org.depromeet.sambad.moring.meeting.answer.domain.MeetingAnswer;
+import org.depromeet.sambad.moring.meeting.answer.infrastructure.dto.MyMeetingAnswerResponseCustom;
+import org.depromeet.sambad.moring.meeting.answer.presentation.response.MyMeetingAnswerListResponse;
+import org.depromeet.sambad.moring.meeting.comment.domain.comment.MeetingQuestionComment;
 import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.StringExpression;
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -20,18 +28,29 @@ import lombok.RequiredArgsConstructor;
 @Repository
 public class MeetingAnswerQueryRepository {
 
-	private final JPAQueryFactory query;
+	private final JPAQueryFactory queryFactory;
+
+	public boolean isAllAnsweredByMeetingIdAndMeetingQuestionId(Long meetingId, Long meetingQuestionId) {
+		return queryFactory.select(meetingAnswer.count())
+			.from(meetingAnswer)
+			.where(meetingAnswer.meetingQuestion.id.eq(meetingQuestionId))
+			.fetchOne()
+			.equals(queryFactory.select(meetingMember.count())
+				.from(meetingMember)
+				.where(meetingMember.meeting.id.eq(meetingId))
+				.fetchOne());
+	}
 
 	// TODO: 가장 많이 선택된 답변이 여러개일 수 있으나, 현재 로직은 하나만 반환. 추후 기획에 따라 수정 필요.
 	public List<MeetingAnswer> findMostSelectedMeetingAnswer(Long meetingQuestionId) {
-		Long mostSelectedAnswerId = query.select(meetingAnswer.answer.id)
+		Long mostSelectedAnswerId = queryFactory.select(meetingAnswer.answer.id)
 			.from(meetingAnswer)
 			.where(meetingAnswer.meetingQuestion.id.eq(meetingQuestionId))
 			.groupBy(meetingAnswer.answer.id)
 			.orderBy(meetingAnswer.answer.id.count().desc())
 			.fetchFirst();
 
-		return query.selectFrom(meetingAnswer)
+		return queryFactory.selectFrom(meetingAnswer)
 			.where(meetingAnswer.answer.id.eq(mostSelectedAnswerId))
 			.fetch();
 	}
@@ -45,7 +64,7 @@ public class MeetingAnswerQueryRepository {
 			"GROUP_CONCAT(DISTINCT {0})", meetingAnswer.answer.id)
 			.as("answer_ids");
 
-		List<Tuple> answerIdsByMember = query.select(meetingAnswer.meetingMember, answerIdsExpression)
+		List<Tuple> answerIdsByMember = queryFactory.select(meetingAnswer.meetingMember, answerIdsExpression)
 			.from(meetingAnswer)
 			.where(meetingAnswer.meetingQuestion.id.eq(meetingQuestionId)
 				.and(meetingAnswer.answer.id.in(answerIds)))
@@ -58,5 +77,26 @@ public class MeetingAnswerQueryRepository {
 			.filter(tuple -> Objects.equals(tuple.get(answerIdsExpression), answerIdsToString))
 			.map(tuple -> tuple.get(meetingAnswer.meetingMember))
 			.toList();
+	}
+
+	public MyMeetingAnswerListResponse findAllByMeetingMemberId(Long meetingMemberId) {
+		List<MyMeetingAnswerResponseCustom> responseCustoms = queryFactory.select(Projections.constructor(
+				MyMeetingAnswerResponseCustom.class,
+				meetingAnswer.meetingQuestion.as("meetingQuestion"),
+				meetingAnswer.as("meetingAnswer"),
+				as(getMyComment(meetingMemberId), "comment")
+			))
+			.from(meetingAnswer)
+			.where(meetingAnswer.meetingMember.id.eq(meetingMemberId))
+			.fetch();
+
+		return MyMeetingAnswerListResponse.from(responseCustoms);
+	}
+
+	private JPQLQuery<MeetingQuestionComment> getMyComment(Long memberId) {
+		return select(meetingQuestionComment)
+			.from(meetingQuestionComment)
+			.where(meetingQuestionComment.meetingMember.id.eq(memberId),
+				meetingQuestionComment.meetingQuestion.eq(meetingAnswer.meetingQuestion));
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerRepositoryImpl.java
@@ -1,23 +1,12 @@
 package org.depromeet.sambad.moring.meeting.answer.infrastructure;
 
-import static com.querydsl.core.types.dsl.Expressions.*;
-import static com.querydsl.jpa.JPAExpressions.*;
-import static org.depromeet.sambad.moring.meeting.answer.domain.QMeetingAnswer.*;
-import static org.depromeet.sambad.moring.meeting.comment.domain.comment.QMeetingQuestionComment.*;
-
 import java.util.List;
 
 import org.depromeet.sambad.moring.meeting.answer.application.MeetingAnswerRepository;
 import org.depromeet.sambad.moring.meeting.answer.domain.MeetingAnswer;
-import org.depromeet.sambad.moring.meeting.answer.infrastructure.dto.MyMeetingAnswerResponseCustom;
 import org.depromeet.sambad.moring.meeting.answer.presentation.response.MyMeetingAnswerListResponse;
-import org.depromeet.sambad.moring.meeting.comment.domain.comment.MeetingQuestionComment;
 import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
 import org.springframework.stereotype.Repository;
-
-import com.querydsl.core.types.Projections;
-import com.querydsl.jpa.JPQLQuery;
-import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,12 +15,22 @@ import lombok.RequiredArgsConstructor;
 public class MeetingAnswerRepositoryImpl implements MeetingAnswerRepository {
 
 	private final MeetingAnswerJpaRepository meetingAnswerJpaRepository;
-	private final JPAQueryFactory queryFactory;
 	private final MeetingAnswerQueryRepository meetingAnswerQueryRepository;
 
 	@Override
 	public void save(MeetingAnswer meetingAnswer) {
 		meetingAnswerJpaRepository.save(meetingAnswer);
+	}
+
+	@Override
+	public boolean existsByMeetingMember(Long meetingQuestionId, Long meetingMemberId) {
+		return meetingAnswerJpaRepository.existsByMeetingQuestionIdAndMeetingMemberId(meetingQuestionId,
+			meetingMemberId);
+	}
+
+	@Override
+	public boolean isAllAnsweredByMeetingIdAndMeetingQuestionId(Long meetingId, Long meetingQuestionId) {
+		return meetingAnswerQueryRepository.isAllAnsweredByMeetingIdAndMeetingQuestionId(meetingId, meetingQuestionId);
 	}
 
 	@Override
@@ -50,30 +49,7 @@ public class MeetingAnswerRepositoryImpl implements MeetingAnswerRepository {
 	}
 
 	@Override
-	public boolean existsByMeetingMember(Long meetingQuestionId, Long meetingMemberId) {
-		return meetingAnswerJpaRepository.existsByMeetingQuestionIdAndMeetingMemberId(meetingQuestionId,
-			meetingMemberId);
-	}
-
-	@Override
 	public MyMeetingAnswerListResponse findAllByMeetingMemberId(Long meetingMemberId) {
-		List<MyMeetingAnswerResponseCustom> responseCustoms = queryFactory.select(Projections.constructor(
-				MyMeetingAnswerResponseCustom.class,
-				meetingAnswer.meetingQuestion.as("meetingQuestion"),
-				meetingAnswer.as("meetingAnswer"),
-				as(getMyComment(meetingMemberId), "comment")
-			))
-			.from(meetingAnswer)
-			.where(meetingAnswer.meetingMember.id.eq(meetingMemberId))
-			.fetch();
-
-		return MyMeetingAnswerListResponse.from(responseCustoms);
-	}
-
-	private JPQLQuery<MeetingQuestionComment> getMyComment(Long memberId) {
-		return select(meetingQuestionComment)
-			.from(meetingQuestionComment)
-			.where(meetingQuestionComment.meetingMember.id.eq(memberId),
-				meetingQuestionComment.meetingQuestion.eq(meetingAnswer.meetingQuestion));
+		return meetingAnswerQueryRepository.findAllByMeetingMemberId(meetingMemberId);
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/domain/Meeting.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/domain/Meeting.java
@@ -58,6 +58,10 @@ public class Meeting extends BaseTimeEntity {
 		return new Meeting(request.name(), meetingCode);
 	}
 
+	public void addMeetingQuestion(MeetingQuestion meetingQuestion) {
+		this.meetingQuestions.add(meetingQuestion);
+	}
+
 	public String getCode() {
 		return Optional.ofNullable(code)
 			.map(MeetingCode::getCode)

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMember.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMember.java
@@ -27,7 +27,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -112,6 +111,10 @@ public class MeetingMember extends BaseTimeEntity implements Comparable<MeetingM
 			request.location(),
 			request.mbti(),
 			request.introduction());
+	}
+
+	public void addMeetingQuestion(MeetingQuestion meetingQuestion) {
+		this.meetingQuestions.add(meetingQuestion);
 	}
 
 	public String getProfileImageUrl() {

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionRepository.java
@@ -12,6 +12,8 @@ public interface MeetingQuestionRepository {
 
 	MeetingQuestion save(MeetingQuestion meetingQuestion);
 
+	Optional<MeetingQuestion> findNextQuestion(Long meetingId);
+
 	boolean existsByQuestion(Long meetingId, Long questionId);
 
 	ActiveMeetingQuestionResponse findActiveOneByMeeting(Long meetingId, Long loginMeetingMemberId);

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/domain/MeetingQuestionStatus.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/domain/MeetingQuestionStatus.java
@@ -1,0 +1,5 @@
+package org.depromeet.sambad.moring.meeting.question.domain;
+
+public enum MeetingQuestionStatus {
+	ACTIVE, INACTIVE, NOT_STARTED;
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionQueryRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionQueryRepository.java
@@ -1,0 +1,161 @@
+package org.depromeet.sambad.moring.meeting.question.infrastructure;
+
+import static com.querydsl.jpa.JPAExpressions.*;
+import static org.depromeet.sambad.moring.meeting.answer.domain.QMeetingAnswer.*;
+import static org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion.*;
+import static org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestionStatus.*;
+import static org.depromeet.sambad.moring.meeting.question.domain.QMeetingQuestion.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.depromeet.sambad.moring.answer.domain.Answer;
+import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
+import org.depromeet.sambad.moring.meeting.question.presentation.response.ActiveMeetingQuestionResponse;
+import org.depromeet.sambad.moring.meeting.question.presentation.response.FullInactiveMeetingQuestionListResponse;
+import org.depromeet.sambad.moring.meeting.question.presentation.response.MostInactiveMeetingQuestionListResponse;
+import org.depromeet.sambad.moring.meeting.question.presentation.response.MostInactiveMeetingQuestionListResponseDetail;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MeetingQuestionQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	public Optional<MeetingQuestion> findNextQuestion(Long meetingId) {
+		MeetingQuestion nextQuestion = queryFactory
+			.select(meetingQuestion)
+			.from(meetingQuestion)
+			.where(
+				meetingQuestion.meeting.id.eq(meetingId),
+				meetingQuestion.meetingQuestionStatus.eq(NOT_STARTED)
+			)
+			.orderBy(meetingQuestion.startTime.asc())
+			.limit(1)
+			.fetchFirst();
+		return Optional.of(nextQuestion);
+	}
+
+	public ActiveMeetingQuestionResponse findActiveOneByMeeting(Long meetingId, Long loginMeetingMemberId) {
+		Optional<MeetingQuestion> activeMeetingQuestion = findActiveQuestion(meetingId);
+
+		if (activeMeetingQuestion.isEmpty()) {
+			return null;
+		}
+		if (activeMeetingQuestion.get().getQuestion() == null) {
+			return ActiveMeetingQuestionResponse.questionNotRegisteredOf(activeMeetingQuestion.get());
+		}
+		return ActiveMeetingQuestionResponse.questionRegisteredOf(activeMeetingQuestion.get(),
+			isAnswered(activeMeetingQuestion.get().getId(), loginMeetingMemberId));
+	}
+
+	public Optional<MeetingQuestion> findActiveOneByMeeting(Long meetingId) {
+		return findActiveQuestion(meetingId);
+	}
+
+	public MostInactiveMeetingQuestionListResponse findMostInactiveList(Long meetingId, Long loginMeetingMemberId) {
+		List<MeetingQuestion> inactiveMeetingQuestions = queryFactory
+			.select(meetingQuestion)
+			.from(meetingQuestion)
+			.where(
+				meetingQuestion.meeting.id.eq(meetingId),
+				inactiveCond()
+			)
+			.orderBy(orderDescByMeetingAnswerCount())
+			.limit(2)
+			.fetch();
+
+		List<MostInactiveMeetingQuestionListResponseDetail> responseDetails = inactiveMeetingQuestions.stream()
+			.map(meetingQuestion -> MostInactiveMeetingQuestionListResponseDetail.of(meetingQuestion,
+				getBestAnswer(meetingQuestion)))
+			.toList();
+		return MostInactiveMeetingQuestionListResponse.from(responseDetails);
+	}
+
+	public FullInactiveMeetingQuestionListResponse findFullInactiveList(Long meetingId, Long loginMeetingMemberId,
+		Pageable pageable) {
+		List<MeetingQuestion> inactiveMeetingQuestions = queryFactory
+			.select(meetingQuestion)
+			.from(meetingQuestion)
+			.where(
+				meetingQuestion.meeting.id.eq(meetingId),
+				inactiveCond()
+			)
+			.orderBy(orderDescByMeetingAnswerCount())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		return FullInactiveMeetingQuestionListResponse.of(inactiveMeetingQuestions, pageable);
+	}
+
+	private Optional<MeetingQuestion> findActiveQuestion(Long meetingId) {
+		return Optional.ofNullable(
+			queryFactory
+				.selectFrom(meetingQuestion)
+				.where(meetingQuestion.meeting.id.eq(meetingId),
+					activeCond())
+				.fetchOne()
+		);
+	}
+
+	private OrderSpecifier<Long> orderDescByMeetingAnswerCount() {
+		// 서브쿼리를 사용하여 각 meetingQuestion에 대한 답변 수를 계산
+		NumberExpression<Long> count = meetingAnswer.count();
+
+		// OrderSpecifier를 사용하여 내림차순 정렬
+		return new OrderSpecifier<>(Order.DESC,
+			select(count)
+				.from(meetingAnswer)
+				.groupBy(meetingAnswer.meetingQuestion));
+	}
+
+	private Answer getBestAnswer(MeetingQuestion meetingQuestion) {
+		return queryFactory
+			.select(meetingAnswer.answer)
+			.from(meetingAnswer)
+			.where(meetingAnswer.meetingQuestion.eq(meetingQuestion))
+			.groupBy(meetingAnswer.answer)
+			.orderBy(meetingAnswer.count().desc())
+			.fetchOne();
+	}
+
+	private Boolean isAnswered(Long meetingQuestionId, Long meetingMemberId) {
+		Integer fetchOne = queryFactory
+			.selectOne()
+			.from(meetingAnswer)
+			.where(meetingAnswer.meetingQuestion.id.eq(meetingQuestionId),
+				meetingAnswer.meetingMember.id.eq(meetingMemberId))
+			.fetchFirst();
+		return fetchOne != null;
+	}
+
+	private BooleanExpression activeCond() {
+		LocalDateTime now = LocalDateTime.now();
+		return meetingQuestion.startTime.loe(now)
+			.and(meetingQuestion.startTime.goe(now.minusHours(RESPONSE_TIME_LIMIT_HOURS)))
+			.and(isAnsweredByAllCond().not());
+	}
+
+	private BooleanExpression inactiveCond() {
+		LocalDateTime now = LocalDateTime.now();
+		return meetingQuestion.startTime.gt(now)
+			.or(meetingQuestion.startTime.lt(now.minusHours(RESPONSE_TIME_LIMIT_HOURS)))
+			.or(isAnsweredByAllCond());
+	}
+
+	private BooleanExpression isAnsweredByAllCond() {
+		return meetingQuestion.memberAnswers.size().eq(meetingQuestion.meeting.meetingMembers.size());
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionRepositoryImpl.java
@@ -1,29 +1,14 @@
 package org.depromeet.sambad.moring.meeting.question.infrastructure;
 
-import static com.querydsl.jpa.JPAExpressions.*;
-import static org.depromeet.sambad.moring.meeting.answer.domain.QMeetingAnswer.*;
-import static org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion.*;
-import static org.depromeet.sambad.moring.meeting.question.domain.QMeetingQuestion.*;
-
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 
-import org.depromeet.sambad.moring.answer.domain.Answer;
 import org.depromeet.sambad.moring.meeting.question.application.MeetingQuestionRepository;
 import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.ActiveMeetingQuestionResponse;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.FullInactiveMeetingQuestionListResponse;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.MostInactiveMeetingQuestionListResponse;
-import org.depromeet.sambad.moring.meeting.question.presentation.response.MostInactiveMeetingQuestionListResponseDetail;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
-
-import com.querydsl.core.types.Order;
-import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.NumberExpression;
-import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 
@@ -32,11 +17,16 @@ import lombok.RequiredArgsConstructor;
 public class MeetingQuestionRepositoryImpl implements MeetingQuestionRepository {
 
 	private final MeetingQuestionJpaRepository meetingQuestionJpaRepository;
-	private final JPAQueryFactory queryFactory;
+	private final MeetingQuestionQueryRepository meetingQuestionQueryRepository;
 
 	@Override
 	public MeetingQuestion save(MeetingQuestion meetingQuestion) {
 		return meetingQuestionJpaRepository.save(meetingQuestion);
+	}
+
+	@Override
+	public Optional<MeetingQuestion> findNextQuestion(Long meetingId) {
+		return meetingQuestionQueryRepository.findNextQuestion(meetingId);
 	}
 
 	@Override
@@ -46,122 +36,27 @@ public class MeetingQuestionRepositoryImpl implements MeetingQuestionRepository 
 
 	@Override
 	public ActiveMeetingQuestionResponse findActiveOneByMeeting(Long meetingId, Long loginMeetingMemberId) {
-		Optional<MeetingQuestion> activeMeetingQuestion = findActiveQuestion(meetingId);
-
-		if (activeMeetingQuestion.isEmpty()) {
-			return null;
-		}
-		if (activeMeetingQuestion.get().getQuestion() == null) {
-			return ActiveMeetingQuestionResponse.questionNotRegisteredOf(activeMeetingQuestion.get());
-		}
-		return ActiveMeetingQuestionResponse.questionRegisteredOf(activeMeetingQuestion.get(),
-			isAnswered(activeMeetingQuestion.get().getId(), loginMeetingMemberId));
+		return meetingQuestionQueryRepository.findActiveOneByMeeting(meetingId, loginMeetingMemberId);
 	}
 
 	@Override
 	public Optional<MeetingQuestion> findActiveOneByMeeting(Long meetingId) {
-		return findActiveQuestion(meetingId);
-	}
-
-	private Optional<MeetingQuestion> findActiveQuestion(Long meetingId) {
-		return Optional.ofNullable(
-			queryFactory
-				.selectFrom(meetingQuestion)
-				.where(meetingQuestion.meeting.id.eq(meetingId),
-					activeCond())
-				.fetchOne()
-		);
+		return meetingQuestionQueryRepository.findActiveOneByMeeting(meetingId);
 	}
 
 	@Override
 	public MostInactiveMeetingQuestionListResponse findMostInactiveList(Long meetingId, Long loginMeetingMemberId) {
-		List<MeetingQuestion> inactiveMeetingQuestions = queryFactory
-			.select(meetingQuestion)
-			.from(meetingQuestion)
-			.where(
-				meetingQuestion.meeting.id.eq(meetingId),
-				inactiveCond()
-			)
-			.orderBy(orderDescByMeetingAnswerCount())
-			.limit(2)
-			.fetch();
-
-		List<MostInactiveMeetingQuestionListResponseDetail> responseDetails = inactiveMeetingQuestions.stream()
-			.map(meetingQuestion -> MostInactiveMeetingQuestionListResponseDetail.of(meetingQuestion,
-				getBestAnswer(meetingQuestion)))
-			.toList();
-		return MostInactiveMeetingQuestionListResponse.from(responseDetails);
+		return meetingQuestionQueryRepository.findMostInactiveList(meetingId, loginMeetingMemberId);
 	}
 
 	@Override
 	public FullInactiveMeetingQuestionListResponse findFullInactiveList(Long meetingId, Long loginMeetingMemberId,
 		Pageable pageable) {
-		List<MeetingQuestion> inactiveMeetingQuestions = queryFactory
-			.select(meetingQuestion)
-			.from(meetingQuestion)
-			.where(
-				meetingQuestion.meeting.id.eq(meetingId),
-				inactiveCond()
-			)
-			.orderBy(orderDescByMeetingAnswerCount())
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
-			.fetch();
-
-		return FullInactiveMeetingQuestionListResponse.of(inactiveMeetingQuestions, pageable);
+		return meetingQuestionQueryRepository.findFullInactiveList(meetingId, loginMeetingMemberId, pageable);
 	}
 
 	@Override
 	public Optional<MeetingQuestion> findByMeetingIdAndMeetingQuestionId(Long meetingId, Long meetingQuestionId) {
 		return meetingQuestionJpaRepository.findByMeetingIdAndId(meetingId, meetingQuestionId);
-	}
-
-	private OrderSpecifier<Long> orderDescByMeetingAnswerCount() {
-		// 서브쿼리를 사용하여 각 meetingQuestion에 대한 답변 수를 계산
-		NumberExpression<Long> count = meetingAnswer.count();
-
-		// OrderSpecifier를 사용하여 내림차순 정렬
-		return new OrderSpecifier<>(Order.DESC,
-			select(count)
-				.from(meetingAnswer)
-				.groupBy(meetingAnswer.meetingQuestion));
-	}
-
-	private Answer getBestAnswer(MeetingQuestion meetingQuestion) {
-		return queryFactory
-			.select(meetingAnswer.answer)
-			.from(meetingAnswer)
-			.where(meetingAnswer.meetingQuestion.eq(meetingQuestion))
-			.groupBy(meetingAnswer.answer)
-			.orderBy(meetingAnswer.count().desc())
-			.fetchOne();
-	}
-
-	private Boolean isAnswered(Long meetingQuestionId, Long meetingMemberId) {
-		Integer fetchOne = queryFactory
-			.selectOne()
-			.from(meetingAnswer)
-			.where(meetingAnswer.meetingQuestion.id.eq(meetingQuestionId),
-				meetingAnswer.meetingMember.id.eq(meetingMemberId))
-			.fetchFirst();
-		return fetchOne != null;
-	}
-
-	private BooleanExpression activeCond() {
-		LocalDateTime now = LocalDateTime.now();
-		return meetingQuestion.startTime.loe(now)
-			.and(meetingQuestion.startTime.goe(now.minusHours(RESPONSE_TIME_LIMIT_HOURS)))
-			.and(isAnsweredByAllCond().not());
-	}
-
-	private BooleanExpression inactiveCond() {
-		LocalDateTime now = LocalDateTime.now();
-		return meetingQuestion.startTime.gt(now)
-			.or(meetingQuestion.startTime.lt(now.minusHours(RESPONSE_TIME_LIMIT_HOURS)))
-			.or(isAnsweredByAllCond());
-	}
-
-	private BooleanExpression isAnsweredByAllCond() {
-		return meetingQuestion.memberAnswers.size().eq(meetingQuestion.meeting.meetingMembers.size());
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/question/domain/Question.java
+++ b/src/main/java/org/depromeet/sambad/moring/question/domain/Question.java
@@ -18,7 +18,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -44,6 +43,10 @@ public class Question extends BaseTimeEntity {
 
 	@OneToMany(mappedBy = "question", fetch = FetchType.LAZY)
 	private List<Answer> answers = new ArrayList<>();
+
+	public void addMeetingQuestion(MeetingQuestion meetingQuestion) {
+		this.meetingQuestions.add(meetingQuestion);
+	}
 
 	public String getQuestionImageUrl() {
 		return Optional.ofNullable(questionImageFile)


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정


## 📝 개요
- 진행 중인 릴레이 질문에 모든 모임원이 답변을 완료했을 때, 현재의 릴레이 질문을 종료(INACTIVE) 처리하고 다음 릴레이 질문을 NOT_STARTED -> ACTIVE 로 status를 업데이트합니다.

## 💡 코드 리뷰 시 참고 사항
- MeetingQuestion 테이블에 status 필드가 추가되었습니다. 개발 서버 반영 시 참고해주셔요.
 