### PR TITLE
[SAMBAD-178] 가입한 모임 목록 조회 API 구현

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/application/MeetingService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/application/MeetingService.java
@@ -5,8 +5,10 @@ import java.util.List;
 import org.depromeet.sambad.moring.meeting.meeting.domain.Meeting;
 import org.depromeet.sambad.moring.meeting.meeting.domain.TypesPerMeeting;
 import org.depromeet.sambad.moring.meeting.meeting.presentation.request.MeetingPersistRequest;
+import org.depromeet.sambad.moring.meeting.meeting.presentation.response.MeetingResponse;
+import org.depromeet.sambad.moring.meeting.member.application.MeetingMemberRepository;
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
 import org.depromeet.sambad.moring.meeting.member.domain.MeetingMemberValidator;
-import org.depromeet.sambad.moring.meeting.question.application.MeetingQuestionService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,11 +16,11 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Service
+@Transactional(readOnly = true)
 public class MeetingService {
 
-	private final MeetingQuestionService meetingQuestionService;
-
 	private final MeetingRepository meetingRepository;
+	private final MeetingMemberRepository meetingMemberRepository;
 	private final MeetingTypeRepository meetingTypeRepository;
 	private final MeetingCodeGenerator meetingCodeGenerator;
 	private final MeetingMemberValidator meetingMemberValidator;
@@ -34,6 +36,15 @@ public class MeetingService {
 		// 해당 로직 추가한 이유가 궁금합니다.
 		// meetingQuestionService.createActiveQuestion(meeting, meeting.getOwner(), null);
 		return meeting;
+	}
+
+	public MeetingResponse getMeetingResponse(Long userId) {
+		List<MeetingMember> membersOfUser = meetingMemberRepository.findByUserId(userId);
+		List<Meeting> meetings = membersOfUser.stream()
+			.map(MeetingMember::getMeeting)
+			.toList();
+
+		return MeetingResponse.from(meetings);
 	}
 
 	private void addTypesToMeeting(MeetingPersistRequest request, Meeting meeting) {

--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/MeetingController.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/MeetingController.java
@@ -10,6 +10,7 @@ import org.depromeet.sambad.moring.meeting.meeting.domain.Meeting;
 import org.depromeet.sambad.moring.meeting.meeting.domain.MeetingType;
 import org.depromeet.sambad.moring.meeting.meeting.presentation.request.MeetingPersistRequest;
 import org.depromeet.sambad.moring.meeting.meeting.presentation.response.MeetingPersistResponse;
+import org.depromeet.sambad.moring.meeting.meeting.presentation.response.MeetingResponse;
 import org.depromeet.sambad.moring.meeting.meeting.presentation.response.MeetingTypeResponse;
 import org.depromeet.sambad.moring.user.presentation.resolver.UserId;
 import org.springframework.http.ResponseEntity;
@@ -34,6 +35,17 @@ public class MeetingController {
 
 	private final MeetingService meetingService;
 	private final MeetingTypeService meetingTypeService;
+
+	@Operation(summary = "모임 조회", description = "가입되어 있는 모임 목록을 조회합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "모임 조회 성공"),
+	})
+	@GetMapping
+	public ResponseEntity<MeetingResponse> getMeetings(@UserId Long userId) {
+		MeetingResponse response = meetingService.getMeetingResponse(userId);
+
+		return ResponseEntity.ok(response);
+	}
 
 	@Operation(summary = "모임 생성", description = "모임을 생성합니다.")
 	@ApiResponses({

--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/response/MeetingResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/response/MeetingResponse.java
@@ -1,0 +1,22 @@
+package org.depromeet.sambad.moring.meeting.meeting.presentation.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
+import java.util.List;
+
+import org.depromeet.sambad.moring.meeting.meeting.domain.Meeting;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MeetingResponse(
+	@Schema(description = "모임 ID 목록", example = "[1, 2, 3]", requiredMode = REQUIRED)
+	List<Long> meetingIds
+) {
+	public static MeetingResponse from(List<Meeting> meetings) {
+		return new MeetingResponse(
+			meetings.stream()
+				.map(Meeting::getId)
+				.toList()
+		);
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberRepository.java
@@ -10,7 +10,7 @@ public interface MeetingMemberRepository {
 
 	Optional<MeetingMember> findById(Long meetingMemberId);
 
-	Optional<MeetingMember> findByUserId(Long userId);
+	List<MeetingMember> findByUserId(Long userId);
 
 	Optional<MeetingMember> findByUserIdAndMeetingId(Long userId, Long meetingId);
 

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberService.java
@@ -110,7 +110,7 @@ public class MeetingMemberService {
 			meetingMemberValidator.validateHostMaxCount(meeting.getId());
 		}
 
-		meetingMemberValidator.validateAlreadyExistMember(userId);
+		meetingMemberValidator.validateAlreadyExistMember(userId, meeting.getId());
 		meetingMemberValidator.validateMeetingMaxCount(userId);
 		meetingMemberValidator.validateMeetingMemberMaxCount(meeting.getId());
 	}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMemberValidator.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMemberValidator.java
@@ -28,8 +28,8 @@ public class MeetingMemberValidator {
 		}
 	}
 
-	public void validateAlreadyExistMember(Long userId) {
-		meetingMemberRepository.findByUserId(userId)
+	public void validateAlreadyExistMember(Long userId, Long meetingId) {
+		meetingMemberRepository.findByUserIdAndMeetingId(userId, meetingId)
 			.ifPresent(meetingMember -> {
 				throw new MeetingMemberAlreadyExistsException();
 			});

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/infrastructure/MeetingMemberJpaRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/infrastructure/MeetingMemberJpaRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MeetingMemberJpaRepository extends JpaRepository<MeetingMember, Long> {
 
-	Optional<MeetingMember> findByUserId(Long userId);
+	List<MeetingMember> findByUserId(Long userId);
 
 	List<MeetingMember> findByMeetingIdOrderByName(Long meetingId);
 

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/infrastructure/MeetingMemberRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/infrastructure/MeetingMemberRepositoryImpl.java
@@ -27,7 +27,7 @@ public class MeetingMemberRepositoryImpl implements MeetingMemberRepository {
 	}
 
 	@Override
-	public Optional<MeetingMember> findByUserId(Long userId) {
+	public List<MeetingMember> findByUserId(Long userId) {
 		return meetingMemberJpaRepository.findByUserId(userId);
 	}
 


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- `GET /v1/meetings` API를 통해, 현재 가입되어 있는 모임의 목록을 확인할 수 있도록 구현합니다.
- 이미 가입한 모임인지 검증하는 메서드가 모임이 여러개인 경우를 고려하지 않은 이슈를 수정합니다.

## 🔗 ISSUE 링크
- resolved [SAMBAD-178](https://www.notion.so/depromeet/API-bdb619b0d99e46d097c13db3c5084840?pvs=4)