### PR TITLE
[SAMBAD-176]- response 필드 규칙 통일

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/presentation/response/MyMeetingAnswerListResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/presentation/response/MyMeetingAnswerListResponse.java
@@ -14,7 +14,7 @@ public record MyMeetingAnswerListResponse(
 		example = "[{\"idx\":1,\"title\":\"갖고 싶은 초능력은?\",\"content\":\"분신술\",\"commentContent\":\"요새 할 일이 너무 많아요ㅠ 분신술로 시간 단축!!\"}]",
 		requiredMode = REQUIRED
 	)
-	List<MyMeetingAnswerListResponseDetail> content
+	List<MyMeetingAnswerListResponseDetail> contents
 ) {
 
 	public static MyMeetingAnswerListResponse from(List<MyMeetingAnswerResponseCustom> content) {

--- a/src/main/java/org/depromeet/sambad/moring/meeting/comment/presentation/comment/response/MeetingCommentListResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/comment/presentation/comment/response/MeetingCommentListResponse.java
@@ -11,10 +11,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record MeetingCommentListResponse(
 	@Schema(
 		description = "릴레이질문 코멘트 목록",
-		example = "[{\"id\":1,\"content\":\"코멘트 예시 입니다.\",\"writer\":{\"meetingMemberId\":1,\"name\":\"이한음\",\"profileImageFileUrl\":\"https://example.com\",\"role\":\"OWNER\"}}]",
+		example = "[{\"meetingQuestionCommentId\":1,\"content\":\"코멘트 예시 입니다.\",\"writer\":{\"meetingMemberId\":1,\"name\":\"이한음\",\"profileImageFileUrl\":\"https://example.com\",\"role\":\"OWNER\"}}]",
 		requiredMode = REQUIRED
 	)
-	List<MeetingCommentListResponseDetail> content
+	List<MeetingCommentListResponseDetail> contents
 ) {
 	public static MeetingCommentListResponse from(List<MeetingQuestionComment> comments) {
 		return new MeetingCommentListResponse(MeetingCommentListResponseDetail.from(comments));

--- a/src/main/java/org/depromeet/sambad/moring/meeting/comment/presentation/comment/response/MeetingCommentListResponseDetail.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/comment/presentation/comment/response/MeetingCommentListResponseDetail.java
@@ -14,7 +14,7 @@ import lombok.Builder;
 @Builder
 public record MeetingCommentListResponseDetail(
 	@Schema(description = "릴레이질문 코멘트 ID", example = "1", requiredMode = REQUIRED)
-	Long id,
+	Long meetingQuestionCommentId,
 
 	@Schema(description = "릴레이질문 코멘트 내용", example = "코멘트 예시 입니다.", requiredMode = REQUIRED)
 	String content,
@@ -26,7 +26,7 @@ public record MeetingCommentListResponseDetail(
 		MeetingMember writer = meetingQuestionComment.getMeetingMember();
 
 		return MeetingCommentListResponseDetail.builder()
-			.id(meetingQuestionComment.getId())
+			.meetingQuestionCommentId(meetingQuestionComment.getId())
 			.content(meetingQuestionComment.getContent())
 			.writer(MeetingMemberListResponseDetail.from(writer))
 			.build();

--- a/src/main/java/org/depromeet/sambad/moring/meeting/comment/presentation/reply/response/MeetingQuestionCommentReplyResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/comment/presentation/reply/response/MeetingQuestionCommentReplyResponse.java
@@ -12,7 +12,7 @@ import lombok.Builder;
 @Builder
 public record MeetingQuestionCommentReplyResponse(
 	@Schema(description = "릴레이질문 코멘트 답글 ID", example = "1", requiredMode = REQUIRED)
-	Long id,
+	Long meetingQuestionCommentReplyId,
 
 	@Schema(description = "릴레이질문 코멘트 답글 내용", example = "코멘트 답글 예시 입니다.", requiredMode = REQUIRED)
 	String content,
@@ -23,7 +23,7 @@ public record MeetingQuestionCommentReplyResponse(
 	public static MeetingQuestionCommentReplyResponse from(MeetingQuestionCommentReply commentReply) {
 		MeetingMember writer = commentReply.getMeetingMember();
 		MeetingQuestionCommentReplyResponseBuilder builder = MeetingQuestionCommentReplyResponse.builder()
-			.id(commentReply.getId())
+			.meetingQuestionCommentReplyId(commentReply.getId())
 			.content(commentReply.getContent())
 			.writer(MeetingMemberListResponseDetail.from(writer));
 		return builder.build();

--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/request/MeetingPersistRequest.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/request/MeetingPersistRequest.java
@@ -19,6 +19,6 @@ public record MeetingPersistRequest(
 	@Schema(description = "모임 유형의 ID 목록", example = "[1,3]", requiredMode = REQUIRED)
 	@NotNull
 	@Size(max = 2)
-	List<Long> typeIds
+	List<Long> meetingTypeIds
 ) {
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/response/MeetingTypeResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/response/MeetingTypeResponse.java
@@ -9,13 +9,13 @@ import org.depromeet.sambad.moring.meeting.meeting.domain.MeetingType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record MeetingTypeResponse(
-	@Schema(example = "[{\"id\": 1, \"content\": \"💩 똥\"}]", description = "모임 유형 목록", requiredMode = REQUIRED)
+	@Schema(example = "[{\"meetingTypeId\": 1, \"content\": \"💩 똥\"}]", description = "모임 유형 목록", requiredMode = REQUIRED)
 	List<MeetingTypeDetail> contents
 ) {
 
 	record MeetingTypeDetail(
 		@Schema(example = "1", description = "모임 타입 ID", requiredMode = REQUIRED)
-		Long id,
+		Long meetingTypeId,
 
 		@Schema(example = "💩 똥", description = "모임 유형", requiredMode = REQUIRED)
 		String content

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/response/HobbyResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/response/HobbyResponse.java
@@ -10,7 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record HobbyResponse(
 	@Schema(
-		example = "[{\"id\": 1, \"content\": \"💩 똥\"}]",
+		example = "[{\"hobbyId\": 1, \"content\": \"💩 똥\"}]",
 		description = "모임원 취미 목록",
 		requiredMode = REQUIRED
 	)
@@ -19,7 +19,7 @@ public record HobbyResponse(
 
 	record HobbyDetail(
 		@Schema(example = "1", description = "모임원 취미 ID", requiredMode = REQUIRED)
-		Long id,
+		Long hobbyId,
 
 		@Schema(example = "💩 똥", description = "모임원 취미 내용", requiredMode = REQUIRED)
 		String content

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/response/MeetingMemberListResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/response/MeetingMemberListResponse.java
@@ -11,7 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record MeetingMemberListResponse(
 	@Schema(
 		description = "모임원 목록",
-		example = "[{\"id\":1,\"name\":\"이한음\",\"profileImageFileUrl\":\"https://example.com\",\"role\":\"OWNER\"}]",
+		example = "[{\"meetingMemberId\":1,\"name\":\"이한음\",\"profileImageFileUrl\":\"https://example.com\",\"role\":\"OWNER\"}]",
 		requiredMode = REQUIRED
 	)
 	List<MeetingMemberListResponseDetail> contents

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/response/MeetingMemberResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/response/MeetingMemberResponse.java
@@ -15,7 +15,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record MeetingMemberResponse(
 	@Schema(description = "모임원 ID", example = "1", requiredMode = REQUIRED)
-	Long id,
+	Long meetingMemberId,
 
 	@Schema(description = "모임원 이름", example = "이한음", requiredMode = REQUIRED)
 	String name,

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/response/FullInactiveMeetingQuestionListResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/response/FullInactiveMeetingQuestionListResponse.java
@@ -15,7 +15,7 @@ public record FullInactiveMeetingQuestionListResponse<T>(
 		description = "비활성화된 모임 질문 목록",
 		requiredMode = REQUIRED
 	)
-	List<FullInactiveMeetingQuestionListResponseDetail> content,
+	List<FullInactiveMeetingQuestionListResponseDetail> contents,
 
 	@Schema(description = "페이징 정보", requiredMode = REQUIRED)
 	PageableResponse<T> pageable

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/response/MostInactiveMeetingQuestionListResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/response/MostInactiveMeetingQuestionListResponse.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record MostInactiveMeetingQuestionListResponse(
 	@Schema(description = "가장 활동이 적은 모임의 질문 목록", requiredMode = REQUIRED)
-	List<MostInactiveMeetingQuestionListResponseDetail> content
+	List<MostInactiveMeetingQuestionListResponseDetail> contents
 ) {
 
 	public static MostInactiveMeetingQuestionListResponse from(

--- a/src/main/java/org/depromeet/sambad/moring/question/presentation/response/QuestionListResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/question/presentation/response/QuestionListResponse.java
@@ -14,7 +14,7 @@ public record QuestionListResponse<T>(
 		example = "[{\"questionId\":1,\"questionImageFileUrl\":\"https://example.com\",\"title\":\"갖고 싶은 초능력은?\",\"usedCount\":3}]",
 		requiredMode = REQUIRED
 	)
-	List<QuestionSummaryResponse> content,
+	List<QuestionSummaryResponse> contents,
 
 	@Schema(description = "페이징 정보", requiredMode = REQUIRED)
 	PageableResponse<T> pageable


### PR DESCRIPTION
### 📍[SAMBAD-176]- response 필드 규칙 통일


## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정


## 📝 개요
- List 응답은 contents, Ids 와 같이 s를 붙여 규칙을 통일시켰습니다.
- 멤버 id를 필드로 가지고 있을 경우 id가 아닌 MeetingMemberId 같이 구체적으로 작성하였습니다.


## 🔗 ISSUE 링크
- resolved [SAMBAD-이슈번호]()