### PR TITLE
[SAMBAD-175] meeting_question_id 기반 질문 정보 조회 API 추가

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/presentation/MeetingAnswerController.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/presentation/MeetingAnswerController.java
@@ -74,11 +74,11 @@ public class MeetingAnswerController {
 		@ApiResponse(responseCode = "403", description = "USER_NOT_MEMBER_OF_MEETING"),
 		@ApiResponse(responseCode = "404", description = "NOT_FOUND_MEETING_QUESTION")
 	})
-	@GetMapping("/meetings/{meetingId}/questions/{questionId}/answers/most-selected")
+	@GetMapping("/meetings/{meetingId}/questions/{meetingQuestionId}/answers/most-selected")
 	public ResponseEntity<SelectedAnswerResponse> getMostSelectedMeetingAnswer(
 		@UserId Long userId,
-		@Parameter(description = "모임 ID", example = "1", required = true) @PathVariable(name = "meetingId") Long meetingId,
-		@Parameter(description = "모임 질문 ID", example = "1", required = true) @PathVariable(name = "questionId") Long meetingQuestionId
+		@Parameter(description = "모임 ID", example = "1", required = true) @PathVariable Long meetingId,
+		@Parameter(description = "모임 질문 ID", example = "1", required = true) @PathVariable Long meetingQuestionId
 	) {
 		SelectedAnswerResponse response = meetingAnswerResultService.getMostSelectedAnswer(
 			userId, meetingId, meetingQuestionId);
@@ -92,11 +92,11 @@ public class MeetingAnswerController {
 		@ApiResponse(responseCode = "403", description = "USER_NOT_MEMBER_OF_MEETING"),
 		@ApiResponse(responseCode = "404", description = "MEETING_MEMBER_NOT_FOUND")
 	})
-	@GetMapping("/meetings/{meetingId}/questions/{questionId}/answers/selected-same")
+	@GetMapping("/meetings/{meetingId}/questions/{meetingQuestionId}/answers/selected-same")
 	public ResponseEntity<SelectedAnswerResponse> getSelectedSameMeetingAnswers(
 		@UserId Long userId,
-		@Parameter(description = "모임 ID", example = "1", required = true) @PathVariable(name = "meetingId") Long meetingId,
-		@Parameter(description = "모임 질문 ID", example = "1", required = true) @PathVariable(name = "questionId") Long meetingQuestionId
+		@Parameter(description = "모임 ID", example = "1", required = true) @PathVariable Long meetingId,
+		@Parameter(description = "모임 질문 ID", example = "1", required = true) @PathVariable Long meetingQuestionId
 	) {
 		SelectedAnswerResponse response = meetingAnswerResultService.getSelectedSameAnswer(
 			userId, meetingId, meetingQuestionId);

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/presentation/response/SelectedAnswerResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/presentation/response/SelectedAnswerResponse.java
@@ -21,8 +21,7 @@ public record SelectedAnswerResponse(
 	@Schema(description = "선택한 멤버들", requiredMode = REQUIRED)
 	List<MeetingMemberListResponseDetail> selectedMembers
 ) {
-	public static SelectedAnswerResponse from(List<MeetingMember> members,
-		List<MeetingAnswer> answers) {
+	public static SelectedAnswerResponse from(List<MeetingMember> members, List<MeetingAnswer> answers) {
 		return new SelectedAnswerResponse(
 			answers.stream()
 				.map(MeetingAnswer::getAnswerContent)

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionService.java
@@ -17,6 +17,7 @@ import org.depromeet.sambad.moring.meeting.question.presentation.response.Meetin
 import org.depromeet.sambad.moring.meeting.question.presentation.response.MostInactiveMeetingQuestionListResponse;
 import org.depromeet.sambad.moring.question.application.QuestionService;
 import org.depromeet.sambad.moring.question.domain.Question;
+import org.depromeet.sambad.moring.question.presentation.response.QuestionResponse;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -102,6 +103,14 @@ public class MeetingQuestionService {
 	public MeetingQuestion getById(Long meetingId, Long meetingQuestionId) {
 		return meetingQuestionRepository.findByMeetingIdAndMeetingQuestionId(meetingId, meetingQuestionId)
 			.orElseThrow(NotFoundMeetingQuestion::new);
+	}
+
+	/*
+	 * 질문 정보의 경우 Public한 데이터이므로, 따로 권한 체크를 하지 않는다.
+	 */
+	public QuestionResponse getQuestionResponseById(Long meetingId, Long meetingQuestionId) {
+		MeetingQuestion meetingQuestion = getById(meetingId, meetingQuestionId);
+		return QuestionResponse.from(meetingQuestion.getQuestion());
 	}
 
 	private Optional<MeetingQuestion> findActiveMeetingQuestion(Long meetingId) {

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/MeetingQuestionController.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/MeetingQuestionController.java
@@ -53,11 +53,10 @@ public class MeetingQuestionController {
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 
-	@Operation(summary = "현재 릴레이 질문과 다음 질문인 저장", description = "모임의 현재 릴레이 질문과 다음 릴레이 질문인을 저장합니다.")
+	@Operation(summary = "모임 질문 상세 조회", description = "모임 질문 상세 정보를 반환합니다.")
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "201"),
-		@ApiResponse(responseCode = "404", description = "NOT_FOUND_QUESTION"),
-		@ApiResponse(responseCode = "409", description = "DUPLICATE_MEETING_QUESTION / INVALID_MEETING_MEMBER_TARGET")
+		@ApiResponse(responseCode = "200"),
+		@ApiResponse(responseCode = "404", description = "NOT_FOUND_MEETING_QUESTION"),
 	})
 	@GetMapping("/{meetingQuestionId}")
 	public ResponseEntity<QuestionResponse> getById(


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- `GET /v1/meetings/{meetingId}/questions/{meetingQuestionId}` API를 통해 `meetingId`와 `meetingQuestionId` 기반 질문 정보 조회가 가능하도록 합니다.
- 특정 path variable을 client 측에서 이해 가능한 방향으로 수정합니다.

## 🔗 ISSUE 링크
- resolved [SAMBAD-175](https://www.notion.so/depromeet/meetingQuestionId-API-bfcc7e7fccbc469ba66da9f4c9cbe13f?pvs=4)