### PR TITLE
[SAMBAD-181] 답변 통계 API 구현

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/application/MeetingAnswerResultService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/application/MeetingAnswerResultService.java
@@ -32,24 +32,24 @@ public class MeetingAnswerResultService {
 				meetingId, meetingQuestionId)
 			.orElseThrow(NotFoundMeetingQuestion::new);
 
-		List<MeetingAnswer> answers = meetingAnswerRepository.findMostSelected(meetingQuestion.getId());
+		List<MeetingAnswer> meetingAnswers = meetingAnswerRepository.findMostSelected(meetingQuestion.getId());
 
 		List<MeetingMember> members = meetingAnswerRepository.findMeetingMembersSelectWith(
-			meetingQuestionId, MeetingAnswer.getAnswerIds(answers));
+			meetingQuestionId, MeetingAnswer.getAnswerIds(meetingAnswers));
 
-		return SelectedAnswerResponse.from(members, answers);
+		return SelectedAnswerResponse.from(members, meetingAnswers);
 	}
 
 	public SelectedAnswerResponse getSelectedSameAnswer(Long userId, Long meetingId, Long meetingQuestionId) {
 		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
 		MeetingMember meetingMember = meetingMemberService.getByUserIdAndMeetingId(userId, meetingId);
 
-		List<MeetingAnswer> answers = meetingAnswerRepository.findByMeetingQuestionIdAndMeetingMemberId(
+		List<MeetingAnswer> meetingAnswers = meetingAnswerRepository.findByMeetingQuestionIdAndMeetingMemberId(
 			meetingQuestionId, meetingMember.getId());
 
 		List<MeetingMember> members = meetingAnswerRepository.findMeetingMembersSelectWith(
-			meetingQuestionId, MeetingAnswer.getAnswerIds(answers));
+			meetingQuestionId, MeetingAnswer.getAnswerIds(meetingAnswers));
 
-		return SelectedAnswerResponse.from(members, answers);
+		return SelectedAnswerResponse.from(members, meetingAnswers);
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/presentation/response/SelectedAnswerResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/presentation/response/SelectedAnswerResponse.java
@@ -21,12 +21,13 @@ public record SelectedAnswerResponse(
 	@Schema(description = "선택한 멤버들", requiredMode = REQUIRED)
 	List<MeetingMemberListResponseDetail> selectedMembers
 ) {
-	public static SelectedAnswerResponse from(List<MeetingMember> members, List<MeetingAnswer> answers) {
+	public static SelectedAnswerResponse from(List<MeetingMember> members, List<MeetingAnswer> meetingAnswers) {
 		return new SelectedAnswerResponse(
-			answers.stream()
+			meetingAnswers.stream()
 				.map(MeetingAnswer::getAnswerContent)
+				.distinct()
 				.toList(),
-			answers.size(),
+			meetingAnswers.size(),
 			MeetingMemberListResponse.from(members).contents()
 		);
 	}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionRepository.java
@@ -1,10 +1,12 @@
 package org.depromeet.sambad.moring.meeting.question.application;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.ActiveMeetingQuestionResponse;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.FullInactiveMeetingQuestionListResponse;
+import org.depromeet.sambad.moring.meeting.question.presentation.response.MeetingQuestionStatisticsDetail;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.MostInactiveMeetingQuestionListResponse;
 import org.springframework.data.domain.Pageable;
 
@@ -26,4 +28,6 @@ public interface MeetingQuestionRepository {
 		Pageable pageable);
 
 	Optional<MeetingQuestion> findByMeetingIdAndMeetingQuestionId(Long meetingId, Long meetingQuestionId);
+
+	List<MeetingQuestionStatisticsDetail> findStatistics(Long meetingQuestionId);
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionService.java
@@ -2,11 +2,13 @@ package org.depromeet.sambad.moring.meeting.question.application;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.depromeet.sambad.moring.meeting.meeting.domain.Meeting;
 import org.depromeet.sambad.moring.meeting.member.application.MeetingMemberService;
 import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMemberValidator;
 import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
 import org.depromeet.sambad.moring.meeting.question.presentation.exception.DuplicateMeetingQuestionException;
 import org.depromeet.sambad.moring.meeting.question.presentation.exception.NotFoundMeetingQuestion;
@@ -14,6 +16,8 @@ import org.depromeet.sambad.moring.meeting.question.presentation.request.Meeting
 import org.depromeet.sambad.moring.meeting.question.presentation.response.ActiveMeetingQuestionResponse;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.FullInactiveMeetingQuestionListResponse;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.MeetingQuestionAndAnswerListResponse;
+import org.depromeet.sambad.moring.meeting.question.presentation.response.MeetingQuestionStatisticsDetail;
+import org.depromeet.sambad.moring.meeting.question.presentation.response.MeetingQuestionStatisticsResponse;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.MostInactiveMeetingQuestionListResponse;
 import org.depromeet.sambad.moring.question.application.QuestionService;
 import org.depromeet.sambad.moring.question.domain.Question;
@@ -33,6 +37,7 @@ public class MeetingQuestionService {
 
 	private final MeetingMemberService meetingMemberService;
 	private final QuestionService questionService;
+	private final MeetingMemberValidator meetingMemberValidator;
 
 	private final Clock clock;
 
@@ -122,6 +127,14 @@ public class MeetingQuestionService {
 		if (isDuplicateQuestion) {
 			throw new DuplicateMeetingQuestionException();
 		}
+	}
+
+	public MeetingQuestionStatisticsResponse getStatistics(Long userId, Long meetingId, Long meetingQuestionId) {
+		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
+		MeetingQuestion meetingQuestion = getById(meetingId, meetingQuestionId);
+		List<MeetingQuestionStatisticsDetail> statistics = meetingQuestionRepository.findStatistics(meetingQuestion.getId());
+
+		return MeetingQuestionStatisticsResponse.of(statistics);
 	}
 }
 

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionQueryRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionQueryRepository.java
@@ -194,7 +194,7 @@ public class MeetingQuestionQueryRepository {
 		for (int i = 0; i < details.size(); i++) {
 			MeetingQuestionStatisticsDetail detail = details.get(i);
 			details.set(i,
-				new MeetingQuestionStatisticsDetail(i + 1, detail.answer(), detail.count(),
+				new MeetingQuestionStatisticsDetail(i + 1, detail.answerContent(), detail.count(),
 					detail.percentage()));
 		}
 

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionQueryRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionQueryRepository.java
@@ -14,6 +14,7 @@ import org.depromeet.sambad.moring.answer.domain.Answer;
 import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.ActiveMeetingQuestionResponse;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.FullInactiveMeetingQuestionListResponse;
+import org.depromeet.sambad.moring.meeting.question.presentation.response.MeetingQuestionStatisticsDetail;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.MostInactiveMeetingQuestionListResponse;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.MostInactiveMeetingQuestionListResponseDetail;
 import org.springframework.data.domain.Pageable;
@@ -21,7 +22,9 @@ import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -157,5 +160,44 @@ public class MeetingQuestionQueryRepository {
 
 	private BooleanExpression isAnsweredByAllCond() {
 		return meetingQuestion.memberAnswers.size().eq(meetingQuestion.meeting.meetingMembers.size());
+	}
+
+	public List<MeetingQuestionStatisticsDetail> findStatistics(Long meetingQuestionId) {
+		// Get total count for the percentage calculation
+		Optional<Long> optionalTotalCount = Optional.ofNullable(queryFactory
+			.select(meetingAnswer.count())
+			.from(meetingAnswer)
+			.where(meetingAnswer.meetingQuestion.id.eq(meetingQuestionId))
+			.fetchOne());
+
+		if (optionalTotalCount.isEmpty()) {
+			return List.of();
+		}
+
+		long totalCount = optionalTotalCount.get();
+
+		List<MeetingQuestionStatisticsDetail> details = queryFactory
+			.select(Projections.constructor(MeetingQuestionStatisticsDetail.class,
+				Expressions.constant(0), // rank will be handled later
+				meetingAnswer.answer.content,
+				meetingAnswer.answer.id.count().intValue().as("count"),
+				meetingAnswer.answer.id.count().doubleValue().divide(totalCount)
+					.multiply(100).castToNum(Integer.class).as("percentage")
+			))
+			.from(meetingAnswer)
+			.where(meetingAnswer.meetingQuestion.id.eq(meetingQuestionId))
+			.groupBy(meetingAnswer.answer.id, meetingAnswer.answer.content)
+			.orderBy(meetingAnswer.answer.id.count().desc())
+			.fetch();
+
+		// Adjust rank based on the order
+		for (int i = 0; i < details.size(); i++) {
+			MeetingQuestionStatisticsDetail detail = details.get(i);
+			details.set(i,
+				new MeetingQuestionStatisticsDetail(i + 1, detail.answer(), detail.count(),
+					detail.percentage()));
+		}
+
+		return details;
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionRepositoryImpl.java
@@ -1,11 +1,13 @@
 package org.depromeet.sambad.moring.meeting.question.infrastructure;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.depromeet.sambad.moring.meeting.question.application.MeetingQuestionRepository;
 import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.ActiveMeetingQuestionResponse;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.FullInactiveMeetingQuestionListResponse;
+import org.depromeet.sambad.moring.meeting.question.presentation.response.MeetingQuestionStatisticsDetail;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.MostInactiveMeetingQuestionListResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
@@ -58,5 +60,10 @@ public class MeetingQuestionRepositoryImpl implements MeetingQuestionRepository 
 	@Override
 	public Optional<MeetingQuestion> findByMeetingIdAndMeetingQuestionId(Long meetingId, Long meetingQuestionId) {
 		return meetingQuestionJpaRepository.findByMeetingIdAndId(meetingId, meetingQuestionId);
+	}
+
+	@Override
+	public List<MeetingQuestionStatisticsDetail> findStatistics(Long meetingQuestionId) {
+		return meetingQuestionQueryRepository.findStatistics(meetingQuestionId);
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/MeetingQuestionController.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/MeetingQuestionController.java
@@ -5,6 +5,7 @@ import org.depromeet.sambad.moring.meeting.question.presentation.request.Meeting
 import org.depromeet.sambad.moring.meeting.question.presentation.response.ActiveMeetingQuestionResponse;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.FullInactiveMeetingQuestionListResponse;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.MeetingQuestionAndAnswerListResponse;
+import org.depromeet.sambad.moring.meeting.question.presentation.response.MeetingQuestionStatisticsResponse;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.MostInactiveMeetingQuestionListResponse;
 import org.depromeet.sambad.moring.question.presentation.response.QuestionResponse;
 import org.depromeet.sambad.moring.user.presentation.resolver.UserId;
@@ -64,6 +65,24 @@ public class MeetingQuestionController {
 		@Parameter(description = "질문 ID", example = "1", required = true) @PathVariable Long meetingQuestionId
 	) {
 		QuestionResponse response = meetingQuestionService.getQuestionResponseById(meetingId, meetingQuestionId);
+
+		return ResponseEntity.ok().body(response);
+	}
+
+	@Operation(summary = "모임 질문 통계 조회", description = "모임 질문에 대한 통계 정보를 반환합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "질문에 대한 통계 정보 반환 성공"),
+		@ApiResponse(responseCode = "403", description = "USER_NOT_MEMBER_OF_MEETING"),
+		@ApiResponse(responseCode = "404", description = "NOT_FOUND_MEETING_QUESTION")
+	})
+	@GetMapping("/{meetingQuestionId}/statistics")
+	public ResponseEntity<MeetingQuestionStatisticsResponse> getStatisticsByQuestionId(
+		@UserId Long userId,
+		@Parameter(description = "모임 ID", example = "1", required = true) @PathVariable Long meetingId,
+		@Parameter(description = "질문 ID", example = "1", required = true) @PathVariable Long meetingQuestionId
+	) {
+		MeetingQuestionStatisticsResponse response = meetingQuestionService.getStatistics(
+			userId, meetingId, meetingQuestionId);
 
 		return ResponseEntity.ok().body(response);
 	}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/response/MeetingQuestionStatisticsDetail.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/response/MeetingQuestionStatisticsDetail.java
@@ -1,9 +1,20 @@
 package org.depromeet.sambad.moring.meeting.question.presentation.response;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record MeetingQuestionStatisticsDetail(
+	@Schema(description = "선택된 수 기반 순위", example = "1", requiredMode = REQUIRED)
 	int rank,
-	String answer,
+
+	@Schema(description = "답변 내용", example = "💩 똥", requiredMode = REQUIRED)
+	String answerContent,
+
+	@Schema(description = "해당 답변을 선택한 모임원 수", example = "14", requiredMode = REQUIRED)
 	int count,
+
+	@Schema(description = "해당 답변을 선택한 모임원 비율", example = "50", requiredMode = REQUIRED)
 	int percentage
 ) {
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/response/MeetingQuestionStatisticsDetail.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/response/MeetingQuestionStatisticsDetail.java
@@ -1,0 +1,9 @@
+package org.depromeet.sambad.moring.meeting.question.presentation.response;
+
+public record MeetingQuestionStatisticsDetail(
+	int rank,
+	String answer,
+	int count,
+	int percentage
+) {
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/response/MeetingQuestionStatisticsResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/response/MeetingQuestionStatisticsResponse.java
@@ -1,0 +1,11 @@
+package org.depromeet.sambad.moring.meeting.question.presentation.response;
+
+import java.util.List;
+
+public record MeetingQuestionStatisticsResponse(
+	List<MeetingQuestionStatisticsDetail> contents
+) {
+	public static MeetingQuestionStatisticsResponse of(List<MeetingQuestionStatisticsDetail> statistics) {
+		return new MeetingQuestionStatisticsResponse(statistics);
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/response/MeetingQuestionStatisticsResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/response/MeetingQuestionStatisticsResponse.java
@@ -1,8 +1,13 @@
 package org.depromeet.sambad.moring.meeting.question.presentation.response;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record MeetingQuestionStatisticsResponse(
+	@Schema(description = "질문 통계 상세 리스트", requiredMode = REQUIRED)
 	List<MeetingQuestionStatisticsDetail> contents
 ) {
 	public static MeetingQuestionStatisticsResponse of(List<MeetingQuestionStatisticsDetail> statistics) {


### PR DESCRIPTION


## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- `GET /v1/meetings/{meetingId}/questions/{meetingQuestionId}/statistics` API를 통해 해당 질문의 통계 정보를 조회할 수 있도록 구현합니다.
- 하위 정보를 포함합니다.
  - 순위
  - 답변 내용
  - 투표수
  - 투표 비율

## 🔗 ISSUE 링크
- resolved [SAMBAD-181](https://www.notion.so/depromeet/API-bec4b20f29a0406ebd4042e1e861754a?pvs=4)