### PR TITLE
[SAMBAD-186] 특정 답변을 선택한 멤버 조회 쿼리 버그 수정

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/application/MeetingAnswerRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/application/MeetingAnswerRepository.java
@@ -18,7 +18,7 @@ public interface MeetingAnswerRepository {
 
 	List<MeetingAnswer> findByMeetingQuestionIdAndMeetingMemberId(Long meetingQuestionId, Long meetingMemberId);
 
-	List<MeetingMember> findMeetingMembersSelectWith(Long questionId, List<Long> answerIds);
+	List<MeetingMember> findMeetingMembersSelectWith(Long meetingQuestionId, List<Long> answerIds);
 
 	MyMeetingAnswerListResponse findAllByMeetingMemberId(Long meetingMemberId);
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/application/MeetingAnswerResultService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/application/MeetingAnswerResultService.java
@@ -34,8 +34,9 @@ public class MeetingAnswerResultService {
 
 		List<MeetingAnswer> meetingAnswers = meetingAnswerRepository.findMostSelected(meetingQuestion.getId());
 
+		List<Long> answerIds = MeetingAnswer.getDistinctAnswerIds(meetingAnswers);
 		List<MeetingMember> members = meetingAnswerRepository.findMeetingMembersSelectWith(
-			meetingQuestionId, MeetingAnswer.getAnswerIds(meetingAnswers));
+			meetingQuestion.getId(), answerIds);
 
 		return SelectedAnswerResponse.from(members, meetingAnswers);
 	}
@@ -48,7 +49,7 @@ public class MeetingAnswerResultService {
 			meetingQuestionId, meetingMember.getId());
 
 		List<MeetingMember> members = meetingAnswerRepository.findMeetingMembersSelectWith(
-			meetingQuestionId, MeetingAnswer.getAnswerIds(meetingAnswers));
+			meetingQuestionId, MeetingAnswer.getDistinctAnswerIds(meetingAnswers));
 
 		return SelectedAnswerResponse.from(members, meetingAnswers);
 	}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/domain/MeetingAnswer.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/domain/MeetingAnswer.java
@@ -56,10 +56,11 @@ public class MeetingAnswer extends BaseTimeEntity {
 		return answer.getContent();
 	}
 
-	public static List<Long> getAnswerIds(List<MeetingAnswer> answers) {
+	public static List<Long> getDistinctAnswerIds(List<MeetingAnswer> answers) {
 		return answers.stream()
 			.map(meetingAnswer -> meetingAnswer.answer.getId())
 			.filter(Objects::nonNull)
+			.distinct()
 			.toList();
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerQueryRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerQueryRepository.java
@@ -50,6 +50,11 @@ public class MeetingAnswerQueryRepository {
 			.orderBy(meetingAnswer.answer.id.count().desc())
 			.fetchFirst();
 
+		// 답변이 하나도 등록되지 않은 경우
+		if (mostSelectedAnswerId == null) {
+			return List.of();
+		}
+
 		return queryFactory.selectFrom(meetingAnswer)
 			.where(meetingAnswer.answer.id.eq(mostSelectedAnswerId))
 			.fetch();

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerQueryRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerQueryRepository.java
@@ -64,7 +64,7 @@ public class MeetingAnswerQueryRepository {
 	 * 주어진 답변 리스트와 동일한 답변을 선택한 회원을 조회합니다.<br />
 	 * "," 기반으로 유저의 답변 리스트를 CONCAT하여 비교합니다.
 	 */
-	public List<MeetingMember> findSameAnswerSelectMembers(Long meetingQuestionId, List<Long> answerIds) {
+	public List<MeetingMember> findMeetingMembersSelectWith(Long meetingQuestionId, List<Long> answerIds) {
 		StringExpression answerIdsExpression = stringTemplate(
 			"GROUP_CONCAT(DISTINCT {0})", meetingAnswer.answer.id)
 			.as("answer_ids");

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerRepositoryImpl.java
@@ -44,8 +44,8 @@ public class MeetingAnswerRepositoryImpl implements MeetingAnswerRepository {
 	}
 
 	@Override
-	public List<MeetingMember> findMeetingMembersSelectWith(Long questionId, List<Long> answerIds) {
-		return meetingAnswerQueryRepository.findSameAnswerSelectMembers(questionId, answerIds);
+	public List<MeetingMember> findMeetingMembersSelectWith(Long meetingQuestionId, List<Long> answerIds) {
+		return meetingAnswerQueryRepository.findSameAnswerSelectMembers(meetingQuestionId, answerIds);
 	}
 
 	@Override

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerRepositoryImpl.java
@@ -45,7 +45,7 @@ public class MeetingAnswerRepositoryImpl implements MeetingAnswerRepository {
 
 	@Override
 	public List<MeetingMember> findMeetingMembersSelectWith(Long meetingQuestionId, List<Long> answerIds) {
-		return meetingAnswerQueryRepository.findSameAnswerSelectMembers(meetingQuestionId, answerIds);
+		return meetingAnswerQueryRepository.findMeetingMembersSelectWith(meetingQuestionId, answerIds);
 	}
 
 	@Override

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/presentation/MeetingAnswerController.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/presentation/MeetingAnswerController.java
@@ -71,6 +71,7 @@ public class MeetingAnswerController {
 	@Operation(summary = "가장 많이 선택된 답변 조회", description = "가장 많이 선택된 답변과 이를 선택한 모임원 리스트를 조회합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "204", description = "아직 등록된 답변이 없는 경우"),
 		@ApiResponse(responseCode = "403", description = "USER_NOT_MEMBER_OF_MEETING"),
 		@ApiResponse(responseCode = "404", description = "NOT_FOUND_MEETING_QUESTION")
 	})
@@ -83,7 +84,9 @@ public class MeetingAnswerController {
 		SelectedAnswerResponse response = meetingAnswerResultService.getMostSelectedAnswer(
 			userId, meetingId, meetingQuestionId);
 
-		return ResponseEntity.ok(response);
+		return response.content().isEmpty()
+			? ResponseEntity.noContent().build()
+			: ResponseEntity.ok(response);
 	}
 
 	@Operation(summary = "같은 답변을 선택한 모임원 리스트 조회", description = "같은 답변을 선택한 모임원 리스트를 조회합니다.")


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- 특정 답변을 선택한 멤버 조회 쿼리 내의 `answerIds` 구성 시 중복을 제거합니다.
  - e.g., answer_id가 `40`인 답변을 남긴 멤버를 찾아야 하는데, `40,40,40,40,40`을 조회 기준으로 삼아서 동일 답변 선택 멤버 조회가 안됩니다.
- 가장 많이 선택한 답변 조회 시, 아직 등록된 답변이 없을 때 500 에러가 발생하는 현상을 수정합니다.

## 🔗 ISSUE 링크
- resolved [SAMBAD-186](https://www.notion.so/depromeet/9792def9885b4e03a53ac54735595514?pvs=4)