### PR TITLE
[SAMBAD-193] MeetingMember 정렬 버그 수정

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/common/config/SwaggerConfig.java
+++ b/src/main/java/org/depromeet/sambad/moring/common/config/SwaggerConfig.java
@@ -3,6 +3,7 @@ package org.depromeet.sambad.moring.common.config;
 import static java.lang.String.*;
 import static org.springframework.security.config.Elements.*;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -53,6 +54,7 @@ public class SwaggerConfig {
 
 	private List<Server> initializeServers() {
 		return PROFILE_SERVER_URL_MAP.entrySet().stream()
+			.filter(entry -> environment.matchesProfiles(entry.getKey()))
 			.map(entry -> openApiServer(entry.getValue(), "Moring API " + entry.getKey().toUpperCase()))
 			.collect(Collectors.toList());
 	}
@@ -75,15 +77,15 @@ public class SwaggerConfig {
 
 	private String getDescription() {
 		return format("""
-			우리 친해져요! 모임 관리 서비스 MORING API 입니다.\n\n
-			로그인 페이지에 접속 후, 카카오 로그인을 수행하세요.\n\n
-			<ul>
-				<li>1. Local Login Page: <a href="%s" target="_blank">%s</a></li>
-				<li>2. Dev Login Page: <a href="%s" target="_blank">%s</a></li>
-				<li>3. Prod Login Page: <a href="%s" target="_blank">%s</a></li>
-			</ul>\n\n
-			쿠키에 액세스 토큰이 저장되며, 별다른 절차 없이 API를 사용하실 수 있습니다.\n\n
-			예외 응답 안내 문서는 <a href="%s" target="_blank">해당 링크</a>에서 확인하실 수 있습니다.\n\n""",
+				우리 친해져요! 모임 관리 서비스 MORING API 입니다.\n\n
+				로그인 페이지에 접속 후, 카카오 로그인을 수행하세요.\n\n
+				<ul>
+					<li>1. Local Login Page: <a href="%s" target="_blank">%s</a></li>
+					<li>2. Dev Login Page: <a href="%s" target="_blank">%s</a></li>
+					<li>3. Prod Login Page: <a href="%s" target="_blank">%s</a></li>
+				</ul>\n\n
+				쿠키에 액세스 토큰이 저장되며, 별다른 절차 없이 API를 사용하실 수 있습니다.\n\n
+				예외 응답 안내 문서는 <a href="%s" target="_blank">해당 링크</a>에서 확인하실 수 있습니다.\n\n""",
 			getLoginUrlByProfile("local"), getLoginUrlByProfile("local"),
 			getLoginUrlByProfile("dev"), getLoginUrlByProfile("dev"),
 			getLoginUrlByProfile("prod"), getLoginUrlByProfile("prod"),

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerQueryRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerQueryRepository.java
@@ -69,18 +69,19 @@ public class MeetingAnswerQueryRepository {
 			"GROUP_CONCAT(DISTINCT {0})", meetingAnswer.answer.id)
 			.as("answer_ids");
 
-		List<Tuple> answerIdsByMember = queryFactory.select(meetingAnswer.meetingMember, answerIdsExpression)
-			.from(meetingAnswer)
+		List<Tuple> answerIdsByMember = queryFactory.select(meetingMember, answerIdsExpression)
+			.from(meetingMember)
+			.join(meetingAnswer).on(meetingAnswer.meetingMember.eq(meetingMember))
 			.where(meetingAnswer.meetingQuestion.id.eq(meetingQuestionId)
 				.and(meetingAnswer.answer.id.in(answerIds)))
-			.groupBy(meetingAnswer.meetingMember)
+			.groupBy(meetingMember)
 			.fetch();
 
 		String answerIdsToString = String.join(",", answerIds.stream().map(String::valueOf).toList());
 
 		return answerIdsByMember.stream()
 			.filter(tuple -> Objects.equals(tuple.get(answerIdsExpression), answerIdsToString))
-			.map(tuple -> tuple.get(meetingAnswer.meetingMember))
+			.map(tuple -> tuple.get(meetingMember))
 			.toList();
 	}
 

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMember.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMember.java
@@ -139,15 +139,16 @@ public class MeetingMember extends BaseTimeEntity implements Comparable<MeetingM
 
 	@Override
 	public int compareTo(MeetingMember o) {
+		// 지연로딩 객체일 경우, getter를 통해 필드를 가져와야 프록시 객체가 초기화되어 정상적인 비교 수행 가능
 		// OWNER 역할을 가진 멤버가 우선순위를 가짐
-		if (this.role == MeetingMemberRole.OWNER && o.role != MeetingMemberRole.OWNER) {
+		if (this.role == MeetingMemberRole.OWNER && o.getRole() != MeetingMemberRole.OWNER) {
 			return -1;
-		} else if (this.role != MeetingMemberRole.OWNER && o.role == MeetingMemberRole.OWNER) {
+		} else if (this.role != MeetingMemberRole.OWNER && o.getRole() == MeetingMemberRole.OWNER) {
 			return 1;
 		}
 
 		// 둘 다 OWNER 역할이 아니거나 둘 다 OWNER 역할일 때 이름순으로 정렬
-		return this.name.compareTo(o.name);
+		return this.name.compareTo(o.getName());
 	}
 
 	public void validateNextTarget(MeetingMember targetMember) {


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- hibernate proxy 객체의 field 직접 접근 시, 객체 초기화가 수행되지 않아 null이 반환됩니다.
- `MeetingMember.compareTo`에서 비교 대상의 필드에 직접 접근하여 `NullPointException`이 발생하는 이슈를 수정합니다.

## 🔗 ISSUE 링크
- resolved [SAMBAD-193](https://www.notion.so/depromeet/url-Object-Storage-URL-ee8b161116534c3684ba002cdead6eea?pvs=4)