### PR TITLE
[SAMBAD-201] OAuth2 제공자로부터 기본 프로필 이미지가 제공된 경우에 대한 핸들링 추가

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/auth/application/AuthService.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/application/AuthService.java
@@ -12,7 +12,6 @@ import org.depromeet.sambad.moring.user.domain.User;
 import org.depromeet.sambad.moring.user.domain.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 
 import lombok.RequiredArgsConstructor;
 
@@ -75,10 +74,8 @@ public class AuthService {
 	}
 
 	private FileEntity uploadProfileImage(AuthAttributes attributes) {
-		String profileImageUrl = attributes.getProfileImageUrl();
-
-		return StringUtils.hasText(profileImageUrl)
-			? fileService.uploadAndSave(profileImageUrl)
-			: fileService.getRandomProfileImage();
+		return attributes.hasDefaultProfileImage()
+			? fileService.getRandomProfileImage()
+			: fileService.uploadAndSave(attributes.getProfileImageUrl());
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/auth/application/dto/AuthAttributes.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/application/dto/AuthAttributes.java
@@ -16,6 +16,8 @@ public interface AuthAttributes {
 
 	LoginProvider getProvider();
 
+	boolean hasDefaultProfileImage();
+
 	static AuthAttributes of(String providerId, Map<String, Object> attributes) {
 		if (LoginProvider.kakao.isProviderOf(providerId)) {
 			return KakaoAuthAttributes.of(attributes);

--- a/src/main/java/org/depromeet/sambad/moring/auth/application/dto/KakaoAuthAttributes.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/application/dto/KakaoAuthAttributes.java
@@ -5,6 +5,7 @@ import static org.depromeet.sambad.moring.user.domain.LoginProvider.*;
 import java.util.Map;
 
 import org.depromeet.sambad.moring.user.domain.LoginProvider;
+import org.springframework.util.StringUtils;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -16,6 +17,8 @@ import lombok.AllArgsConstructor;
  */
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class KakaoAuthAttributes implements AuthAttributes {
+
+	public static final String DEFAULT_PROFILE_IMAGE_PREFIX = "default_profile";
 
 	private final String id;
 	private final String email;
@@ -59,5 +62,11 @@ public class KakaoAuthAttributes implements AuthAttributes {
 	@Override
 	public LoginProvider getProvider() {
 		return this.provide;
+	}
+
+	@Override
+	public boolean hasDefaultProfileImage() {
+		return !StringUtils.hasText(this.profileImageUrl) ||
+			this.profileImageUrl.contains(DEFAULT_PROFILE_IMAGE_PREFIX);
 	}
 }


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- 프로필 이미지 제공 미동의로 profileImage가 없거나, 기본 프로필 이미지가 제공된 경우 `moring`에서 준비한 기본 이미지가 제공되도록 수정합니다.


## 🔗 ISSUE 링크
- resolved [SAMBAD-201](https://www.notion.so/depromeet/f81393a02e3d4afda8ae7034dc0664db?pvs=4)