### PR TITLE
[SAMBAD-195] redirect url 판단 시, userId가 잘못된 값으로 사용되는 이슈 수정

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/auth/application/AuthService.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/application/AuthService.java
@@ -63,7 +63,7 @@ public class AuthService {
 		refreshTokenEntity.rotate(refreshToken);
 		refreshTokenRepository.save(refreshTokenEntity);
 
-		return new LoginResult(accessToken, refreshToken, firstLogin);
+		return new LoginResult(accessToken, refreshToken, firstLogin, user.getId());
 	}
 
 	private User saveNewUser(AuthAttributes attributes) {

--- a/src/main/java/org/depromeet/sambad/moring/auth/application/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/application/OAuth2LoginSuccessHandler.java
@@ -52,9 +52,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 	}
 
 	private String determineRedirectUrl(LoginResult result) {
-		Long userId = Long.valueOf(SecurityContextHolder.getContext().getAuthentication().getName());
-
-		if (meetingMemberService.isNotEnterAnyMeeting(userId)) {
+		if (meetingMemberService.isNotEnterAnyMeeting(result.userId())) {
 			return result.isNewUser()
 				? securityProperties.newUserRedirectUrl() + "?newUser=true"
 				: securityProperties.newUserRedirectUrl();

--- a/src/main/java/org/depromeet/sambad/moring/auth/application/RefreshTokenService.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/application/RefreshTokenService.java
@@ -35,11 +35,12 @@ public class RefreshTokenService {
 	}
 
 	private LoginResult getReissuedTokenResult(HttpServletResponse response, RefreshToken savedRefreshToken) {
-		String reissuedAccessToken = tokenGenerator.generateAccessToken(savedRefreshToken.getUserId());
+		Long userId = savedRefreshToken.getUserId();
+
+		String reissuedAccessToken = tokenGenerator.generateAccessToken(userId);
 		String rotatedRefreshToken = this.rotate(savedRefreshToken);
 
-		LoginResult loginResult = new LoginResult(reissuedAccessToken, rotatedRefreshToken, false);
-
+		LoginResult loginResult = new LoginResult(reissuedAccessToken, rotatedRefreshToken, false, userId);
 		tokenInjector.injectTokensToCookie(loginResult, response);
 
 		return loginResult;

--- a/src/main/java/org/depromeet/sambad/moring/auth/domain/LoginResult.java
+++ b/src/main/java/org/depromeet/sambad/moring/auth/domain/LoginResult.java
@@ -3,6 +3,7 @@ package org.depromeet.sambad.moring.auth.domain;
 public record LoginResult(
 	String accessToken,
 	String refreshToken,
-	boolean isNewUser
+	boolean isNewUser,
+	Long userId
 ) {
 }


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 📝 개요
- `SecurityContextHolder.getContext().getAuthentication().getName()` 호출 시, `userId`가 아닌 `externalId`가 반환됩니다.
- `LoginResult`에 `userId`를 추가하는 방식으로 수정합니다.


## 🔗 ISSUE 링크
- resolved [SAMBAD-195](https://www.notion.so/depromeet/Redirect-url-3956ca6944cb4f909d244c1ad1eb0150?pvs=4)