### PR TITLE
[SAMBAD-204] 초대 코드 기반 모임명 조회 API 추가

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/application/MeetingService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/application/MeetingService.java
@@ -3,9 +3,12 @@ package org.depromeet.sambad.moring.meeting.meeting.application;
 import java.util.List;
 
 import org.depromeet.sambad.moring.meeting.meeting.domain.Meeting;
+import org.depromeet.sambad.moring.meeting.meeting.domain.MeetingCode;
 import org.depromeet.sambad.moring.meeting.meeting.domain.TypesPerMeeting;
+import org.depromeet.sambad.moring.meeting.meeting.presentation.exception.MeetingNotFoundException;
 import org.depromeet.sambad.moring.meeting.meeting.presentation.request.MeetingPersistRequest;
 import org.depromeet.sambad.moring.meeting.meeting.presentation.response.MeetingResponse;
+import org.depromeet.sambad.moring.meeting.meeting.presentation.response.MeetingNameResponse;
 import org.depromeet.sambad.moring.meeting.member.application.MeetingMemberRepository;
 import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
 import org.depromeet.sambad.moring.meeting.member.domain.MeetingMemberValidator;
@@ -45,6 +48,13 @@ public class MeetingService {
 			.toList();
 
 		return MeetingResponse.from(meetings);
+	}
+
+	public MeetingNameResponse getMeetingNameByCode(String code) {
+		Meeting meeting = meetingRepository.findByCode(MeetingCode.from(code))
+			.orElseThrow(MeetingNotFoundException::new);
+
+		return MeetingNameResponse.from(meeting);
 	}
 
 	private void addTypesToMeeting(MeetingPersistRequest request, Meeting meeting) {

--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/MeetingController.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/MeetingController.java
@@ -11,6 +11,7 @@ import org.depromeet.sambad.moring.meeting.meeting.domain.MeetingType;
 import org.depromeet.sambad.moring.meeting.meeting.presentation.request.MeetingPersistRequest;
 import org.depromeet.sambad.moring.meeting.meeting.presentation.response.MeetingPersistResponse;
 import org.depromeet.sambad.moring.meeting.meeting.presentation.response.MeetingResponse;
+import org.depromeet.sambad.moring.meeting.meeting.presentation.response.MeetingNameResponse;
 import org.depromeet.sambad.moring.meeting.meeting.presentation.response.MeetingTypeResponse;
 import org.depromeet.sambad.moring.user.presentation.resolver.UserId;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -43,6 +45,18 @@ public class MeetingController {
 	@GetMapping
 	public ResponseEntity<MeetingResponse> getMeetings(@UserId Long userId) {
 		MeetingResponse response = meetingService.getMeetingResponse(userId);
+
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "초대 코드 기반 모임명 조회", description = "초대 코드를 기반으로 모임명을 조회하며, 모임 존재 여부를 검증합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "모임명 조회 성공"),
+		@ApiResponse(responseCode = "404", description = "MEETING_NOT_FOUND"),
+	})
+	@GetMapping("/name")
+	public ResponseEntity<MeetingNameResponse> getMeetingName(@RequestParam String code) {
+		MeetingNameResponse response = meetingService.getMeetingNameByCode(code);
 
 		return ResponseEntity.ok(response);
 	}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/response/MeetingNameResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/response/MeetingNameResponse.java
@@ -1,0 +1,11 @@
+package org.depromeet.sambad.moring.meeting.meeting.presentation.response;
+
+import org.depromeet.sambad.moring.meeting.meeting.domain.Meeting;
+
+public record MeetingNameResponse(
+	String title
+) {
+	public static MeetingNameResponse from(Meeting meeting) {
+		return new MeetingNameResponse(meeting.getName());
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/response/MeetingNameResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/response/MeetingNameResponse.java
@@ -1,9 +1,14 @@
 package org.depromeet.sambad.moring.meeting.meeting.presentation.response;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
 import org.depromeet.sambad.moring.meeting.meeting.domain.Meeting;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record MeetingNameResponse(
-	String title
+	@Schema(description = "모임명", example = "삼밧드의 모험", requiredMode = REQUIRED)
+	String name
 ) {
 	public static MeetingNameResponse from(Meeting meeting) {
 		return new MeetingNameResponse(meeting.getName());


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
<img width="830" alt="스크린샷 2024-08-02 오전 1 34 57" src="https://github.com/user-attachments/assets/9d8e5e91-4a62-4959-a064-0cb29ddb031c">
- 위와 같이, 초대 코드를 입력하면 모임에 가입하기 전 모임의 제목을 알아야 합니다.
- 또한, 이 단계에서 모임의 존재 여부를 검증할 필요가 있습니다.

## 🔗 ISSUE 링크
- resolved [SAMBAD-204](https://www.notion.so/depromeet/API-1d0dc2c0f3734c54b4a3cfd6380ae9c4?pvs=4)