### PR TITLE
[SAMBAD-211] 질문의 참여자 목록 조회 API 추가

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionRepository.java
@@ -3,6 +3,7 @@ package org.depromeet.sambad.moring.meeting.question.application;
 import java.util.List;
 import java.util.Optional;
 
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
 import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.ActiveMeetingQuestionResponse;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.FullInactiveMeetingQuestionListResponse;
@@ -29,4 +30,6 @@ public interface MeetingQuestionRepository {
 	Optional<MeetingQuestion> findByMeetingIdAndMeetingQuestionId(Long meetingId, Long meetingQuestionId);
 
 	List<MeetingQuestionStatisticsDetail> findStatistics(Long meetingQuestionId);
+
+	List<MeetingMember> findMeetingMembersByMeetingQuestionId(Long meetingQuestionId);
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionService.java
@@ -9,6 +9,7 @@ import org.depromeet.sambad.moring.meeting.meeting.domain.Meeting;
 import org.depromeet.sambad.moring.meeting.member.application.MeetingMemberService;
 import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
 import org.depromeet.sambad.moring.meeting.member.domain.MeetingMemberValidator;
+import org.depromeet.sambad.moring.meeting.member.presentation.response.MeetingMemberListResponse;
 import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
 import org.depromeet.sambad.moring.meeting.question.presentation.exception.NotFoundMeetingQuestion;
 import org.depromeet.sambad.moring.meeting.question.presentation.request.MeetingQuestionRequest;
@@ -116,6 +117,27 @@ public class MeetingQuestionService {
 		return QuestionResponse.from(meetingQuestion.getQuestion());
 	}
 
+	public MeetingQuestionStatisticsResponse getStatistics(Long userId, Long meetingId, Long meetingQuestionId) {
+		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
+		MeetingQuestion meetingQuestion = getById(meetingId, meetingQuestionId);
+		List<MeetingQuestionStatisticsDetail> statistics = meetingQuestionRepository.findStatistics(
+			meetingQuestion.getId());
+
+		return MeetingQuestionStatisticsResponse.of(statistics);
+	}
+
+	public MeetingMemberListResponse getMeetingMembersByMeetingQuestionId(
+		Long userId, Long meetingId, Long meetingQuestionId
+	) {
+		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
+		MeetingQuestion meetingQuestion = getById(meetingId, meetingQuestionId);
+
+		List<MeetingMember> members = meetingQuestionRepository.findMeetingMembersByMeetingQuestionId(
+			meetingQuestion.getId());
+
+		return MeetingMemberListResponse.from(members);
+	}
+
 	private Optional<MeetingQuestion> findActiveMeetingQuestion(Long meetingId) {
 		return meetingQuestionRepository.findActiveOneByMeeting(meetingId);
 	}
@@ -125,15 +147,6 @@ public class MeetingQuestionService {
 		if (isDuplicateQuestion) {
 			throw new DuplicateQuestionException();
 		}
-	}
-
-	public MeetingQuestionStatisticsResponse getStatistics(Long userId, Long meetingId, Long meetingQuestionId) {
-		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
-		MeetingQuestion meetingQuestion = getById(meetingId, meetingQuestionId);
-		List<MeetingQuestionStatisticsDetail> statistics = meetingQuestionRepository.findStatistics(
-			meetingQuestion.getId());
-
-		return MeetingQuestionStatisticsResponse.of(statistics);
 	}
 }
 

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionQueryRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionQueryRepository.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 
 import org.depromeet.sambad.moring.answer.domain.Answer;
 import org.depromeet.sambad.moring.file.domain.QFileEntity;
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
 import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.ActiveMeetingQuestionResponse;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.FullInactiveMeetingQuestionListResponse;
@@ -203,5 +204,14 @@ public class MeetingQuestionQueryRepository {
 		}
 
 		return details;
+	}
+
+	public List<MeetingMember> findMeetingMembersByMeetingQuestionId(Long meetingQuestionId) {
+		return queryFactory.select(meetingMember)
+			.from(meetingQuestion)
+			.join(meetingQuestion.memberAnswers, meetingAnswer)
+			.join(meetingAnswer.meetingMember, meetingMember)
+			.where(meetingQuestion.id.eq(meetingQuestionId))
+			.fetch();
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionRepositoryImpl.java
@@ -3,6 +3,7 @@ package org.depromeet.sambad.moring.meeting.question.infrastructure;
 import java.util.List;
 import java.util.Optional;
 
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
 import org.depromeet.sambad.moring.meeting.question.application.MeetingQuestionRepository;
 import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.ActiveMeetingQuestionResponse;
@@ -64,5 +65,10 @@ public class MeetingQuestionRepositoryImpl implements MeetingQuestionRepository 
 	@Override
 	public List<MeetingQuestionStatisticsDetail> findStatistics(Long meetingQuestionId) {
 		return meetingQuestionQueryRepository.findStatistics(meetingQuestionId);
+	}
+
+	@Override
+	public List<MeetingMember> findMeetingMembersByMeetingQuestionId(Long meetingQuestionId) {
+		return meetingQuestionQueryRepository.findMeetingMembersByMeetingQuestionId(meetingQuestionId);
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/MeetingQuestionController.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/MeetingQuestionController.java
@@ -30,6 +30,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "모임의 릴레이 질문", description = "모임원이 선택한 릴레이 질문 관련 api / 담당자: 김나현")
@@ -174,8 +175,10 @@ public class MeetingQuestionController {
 	@GetMapping("/{meetingQuestionId}/members")
 	public ResponseEntity<MeetingMemberListResponse> getMeetingMembersByQuestionId(
 		@UserId Long userId,
-		@Parameter(description = "모임 ID", example = "1", required = true) @PathVariable Long meetingId,
-		@Parameter(description = "모임 내 질문 ID", example = "1", required = true) @PathVariable Long meetingQuestionId
+		@Parameter(description = "모임 ID", example = "1", required = true)
+		@Positive @PathVariable Long meetingId,
+		@Parameter(description = "모임 내 질문 ID", example = "1", required = true)
+		@Positive @PathVariable Long meetingQuestionId
 	) {
 		MeetingMemberListResponse response = meetingQuestionService.getMeetingMembersByMeetingQuestionId(
 			userId, meetingId, meetingQuestionId);

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/MeetingQuestionController.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/MeetingQuestionController.java
@@ -2,6 +2,7 @@ package org.depromeet.sambad.moring.meeting.question.presentation;
 
 import static org.springframework.http.HttpStatus.*;
 
+import org.depromeet.sambad.moring.meeting.member.presentation.response.MeetingMemberListResponse;
 import org.depromeet.sambad.moring.meeting.question.application.MeetingQuestionService;
 import org.depromeet.sambad.moring.meeting.question.presentation.request.MeetingQuestionRequest;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.ActiveMeetingQuestionResponse;
@@ -162,5 +163,22 @@ public class MeetingQuestionController {
 		MostInactiveMeetingQuestionListResponse inactiveList = meetingQuestionService.findMostInactiveList(userId,
 			meetingId);
 		return ResponseEntity.ok(inactiveList);
+	}
+
+	@Operation(summary = "모임 질문에 참여한 모임원 조회", description = "모임 질문에 참여한 모임원 목록을 반환합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200"),
+		@ApiResponse(responseCode = "403", description = "USER_NOT_MEMBER_OF_MEETING"),
+		@ApiResponse(responseCode = "404", description = "NOT_FOUND_MEETING_QUESTION")
+	})
+	@GetMapping("/{meetingQuestionId}/members")
+	public ResponseEntity<MeetingMemberListResponse> getMeetingMembersByQuestionId(
+		@UserId Long userId,
+		@Parameter(description = "모임 ID", example = "1", required = true) @PathVariable Long meetingId,
+		@Parameter(description = "모임 내 질문 ID", example = "1", required = true) @PathVariable Long meetingQuestionId
+	) {
+		MeetingMemberListResponse response = meetingQuestionService.getMeetingMembersByMeetingQuestionId(
+			userId, meetingId, meetingQuestionId);
+		return ResponseEntity.ok().body(response);
 	}
 }


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- `meetingId`와 `meetingQuestionId`에 기반하여 모임에 참여한 모임원 목록을 조회할 수 있는 API를 추가합니다.


## 🔗 ISSUE 링크
- resolved [SAMBAD-211](https://www.notion.so/depromeet/API-87873665165047cf8a8c99c8a03fff54?pvs=4)