### PR TITLE
[SAMBAD-216] 모임원 최초 가입 시, 활성 질문 등록 로직 추가

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/application/MeetingAnswerService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/application/MeetingAnswerService.java
@@ -67,7 +67,7 @@ public class MeetingAnswerService {
 					nextQuestion.updateStatusToActive(LocalDateTime.now(clock));
 					MeetingMember targetMember = nextQuestion.getTargetMember();
 
-					eventService.publish(targetMember.getUserId(), meetingId, TARGET_MEMBER);
+					eventService.publish(targetMember.getUser().getId(), meetingId, TARGET_MEMBER);
 				});
 		}
 	}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberRepository.java
@@ -26,4 +26,6 @@ public interface MeetingMemberRepository {
 	boolean isOwnerExceedingMaxMeetings(Long meetingId, int maxHostMeetings);
 
 	boolean isUserMemberOfMeeting(Long userId, Long meetingId);
+
+	boolean isCountOfMembersIsOne(Long meetingId);
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberService.java
@@ -1,5 +1,6 @@
 package org.depromeet.sambad.moring.meeting.member.application;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.depromeet.sambad.moring.meeting.meeting.application.MeetingRepository;
@@ -16,6 +17,8 @@ import org.depromeet.sambad.moring.meeting.member.presentation.response.MeetingM
 import org.depromeet.sambad.moring.meeting.member.presentation.response.MeetingMemberListResponseDetail;
 import org.depromeet.sambad.moring.meeting.member.presentation.response.MeetingMemberPersistResponse;
 import org.depromeet.sambad.moring.meeting.member.presentation.response.MeetingMemberResponse;
+import org.depromeet.sambad.moring.meeting.question.application.MeetingQuestionRepository;
+import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
 import org.depromeet.sambad.moring.user.domain.User;
 import org.depromeet.sambad.moring.user.domain.UserRepository;
 import org.depromeet.sambad.moring.user.presentation.exception.NotFoundUserException;
@@ -35,6 +38,7 @@ public class MeetingMemberService {
 	private final MeetingMemberRepository meetingMemberRepository;
 	private final UserRepository userRepository;
 	private final HobbyRepository hobbyRepository;
+	private final MeetingQuestionRepository meetingQuestionRepository;
 	private final MeetingMemberHobbyRepository meetingMemberHobbyRepository;
 
 	public MeetingMemberListResponse getMeetingMembers(Long userId, Long meetingId) {
@@ -82,7 +86,18 @@ public class MeetingMemberService {
 		MeetingMember meetingMember = validateAndCreateMember(userId, request, meeting, user);
 		addHobbies(meetingMember, request);
 
+		createMeetingQuestionIfFirstMeetingMember(meeting, meetingMember);
+
 		return MeetingMemberPersistResponse.from(meetingMember);
+	}
+
+	private void createMeetingQuestionIfFirstMeetingMember(Meeting meeting, MeetingMember meetingMember) {
+		if (meetingMemberRepository.isCountOfMembersIsOne(meeting.getId())) {
+			MeetingQuestion activeMeetingQuestion = MeetingQuestion.createActiveMeetingQuestion(
+				meeting, meetingMember, null, LocalDateTime.now());
+
+			meetingQuestionRepository.save(activeMeetingQuestion);
+		}
 	}
 
 	public MeetingMemberListResponseDetail getRandomMeetingMember(Long userId, Long meetingId,

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMember.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMember.java
@@ -156,8 +156,4 @@ public class MeetingMember extends BaseTimeEntity implements Comparable<MeetingM
 			throw new InvalidMeetingMemberTargetException();
 		}
 	}
-
-	public Long getUserId() {
-		return user.getId();
-	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/infrastructure/MeetingMemberQueryRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/infrastructure/MeetingMemberQueryRepository.java
@@ -52,4 +52,10 @@ public class MeetingMemberQueryRepository {
 				meetingMember.id.notIn(excludeMemberIds))
 			.fetch();
 	}
+
+	public boolean isCountOfMembersIsOne(Long meetingId) {
+		return query.selectFrom(meetingMember)
+			.where(meetingMember.meeting.id.eq(meetingId))
+			.fetch().size() == 1;
+	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/infrastructure/MeetingMemberRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/infrastructure/MeetingMemberRepositoryImpl.java
@@ -67,4 +67,9 @@ public class MeetingMemberRepositoryImpl implements MeetingMemberRepository {
 	public boolean isUserMemberOfMeeting(Long userId, Long meetingId) {
 		return meetingMemberQueryRepository.isUserMemberOfMeeting(userId, meetingId);
 	}
+
+	@Override
+	public boolean isCountOfMembersIsOne(Long meetingId) {
+		return meetingMemberQueryRepository.isCountOfMembersIsOne(meetingId);
+	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionService.java
@@ -67,7 +67,7 @@ public class MeetingQuestionService {
 
 		eventService.inactivateLastEventByType(userId, meetingId, TARGET_MEMBER);
 		meeting.getMeetingMembers().forEach(member ->
-			eventService.publish(member.getUserId(), meetingId, QUESTION_REGISTERED));
+			eventService.publish(member.getUser().getId(), meetingId, QUESTION_REGISTERED));
 
 		MeetingQuestion nextMeetingQuestion = MeetingQuestion.createNextMeetingQuestion(
 			meeting, nextTargetMember, nowMeetingQuestion.getNextStartTime());


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- 모임에 최초 모임원이 가입한 경우, 활성 질문을 하나 등록해야 해당 모임원이 질문을 등록할 수 있습니다.
  - 모임원 등록 후 모임의 모임원이 한 명인 경우, 해당 모임원을 대상으로 한 활성 질문을 하나 등록합니다.

## 🔗 ISSUE 링크
- resolved [SAMBAD-216](https://www.notion.so/depromeet/91667cbc163e465398b339f21579290a?pvs=4)