### PR TITLE
[SAMBAD-222] 모임 질문 조회 시 활성화, 비활성화 조건 버그 수정 

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionQueryRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionQueryRepository.java
@@ -131,15 +131,15 @@ public class MeetingQuestionQueryRepository {
 		return new OrderSpecifier<>(Order.DESC, meetingQuestion.memberAnswers.size());
 	}
 
-	private Answer getBestAnswer(MeetingQuestion meetingQuestion) {
-		return queryFactory
+	private Optional<Answer> getBestAnswer(MeetingQuestion meetingQuestion) {
+		return Optional.ofNullable(queryFactory
 			.select(meetingAnswer.answer)
 			.from(meetingAnswer)
 			.where(meetingAnswer.meetingQuestion.eq(meetingQuestion))
 			.groupBy(meetingAnswer.answer)
 			.orderBy(meetingAnswer.count().desc())
 			.limit(1)
-			.fetchOne();
+			.fetchOne());
 	}
 
 	private Boolean isAnswered(Long meetingQuestionId, Long meetingMemberId) {

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionQueryRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionQueryRepository.java
@@ -77,6 +77,7 @@ public class MeetingQuestionQueryRepository {
 			.leftJoin(meetingQuestion.memberAnswers, meetingAnswer).fetchJoin()
 			.where(
 				meetingQuestion.meeting.id.eq(meetingId),
+				meetingQuestion.question.isNotNull(),
 				inactiveCond()
 			)
 			.orderBy(orderDescByMeetingAnswerCount(), meetingQuestion.startTime.desc())
@@ -103,6 +104,7 @@ public class MeetingQuestionQueryRepository {
 			.leftJoin(meetingQuestion.question.questionImageFile, questionImageFile).fetchJoin()
 			.where(
 				meetingQuestion.meeting.id.eq(meetingId),
+				meetingQuestion.question.isNotNull(),
 				inactiveCond()
 			)
 			.orderBy(orderDescByMeetingAnswerCount(), meetingQuestion.startTime.desc())
@@ -154,7 +156,8 @@ public class MeetingQuestionQueryRepository {
 		LocalDateTime now = LocalDateTime.now();
 		return meetingQuestion.startTime.loe(now)
 			.and(meetingQuestion.startTime.goe(now.minusHours(RESPONSE_TIME_LIMIT_HOURS)))
-			.and(isAnsweredByAllCond().not());
+			.and(isAnsweredByAllCond().not())
+			.and(meetingQuestion.question.isNotNull());
 	}
 
 	private BooleanExpression inactiveCond() {

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/response/MostInactiveMeetingQuestionListResponseDetail.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/response/MostInactiveMeetingQuestionListResponseDetail.java
@@ -1,6 +1,8 @@
 package org.depromeet.sambad.moring.meeting.question.presentation.response;
 
-import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
+import java.util.Optional;
 
 import org.depromeet.sambad.moring.answer.domain.Answer;
 import org.depromeet.sambad.moring.meeting.meeting.domain.Meeting;
@@ -17,7 +19,7 @@ public record MostInactiveMeetingQuestionListResponseDetail(
 	@Schema(example = "갖고 싶은 초능력은?", description = "모임 질문 TITLE", requiredMode = REQUIRED)
 	String title,
 
-	@Schema(example = "순간이동", description = "가장 많이 선택한 답변", requiredMode = REQUIRED)
+	@Schema(example = "순간이동", description = "가장 많이 선택한 답변", requiredMode = NOT_REQUIRED)
 	String content,
 
 	@Schema(example = "70", description = "참여율, 소수점 첫째 자리에서 반올림하여 반환합니다.", requiredMode = REQUIRED)
@@ -27,13 +29,14 @@ public record MostInactiveMeetingQuestionListResponseDetail(
 	Long startTime
 ) {
 
-	public static MostInactiveMeetingQuestionListResponseDetail of(MeetingQuestion meetingQuestion, Answer bestAnswer) {
+	public static MostInactiveMeetingQuestionListResponseDetail of(MeetingQuestion meetingQuestion,
+		Optional<Answer> bestAnswer) {
 		Meeting meeting = meetingQuestion.getMeeting();
 
 		return MostInactiveMeetingQuestionListResponseDetail.builder()
 			.meetingQuestionId(meetingQuestion.getId())
 			.title(meetingQuestion.getQuestion().getTitle())
-			.content(bestAnswer.getContent())
+			.content(bestAnswer.isPresent() ? bestAnswer.get().getContent() : null)
 			.engagementRate(meeting.calculateEngagementRate(meetingQuestion))
 			.startTime(meetingQuestion.getEpochMilliStartTime())
 			.build();


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- 종료된 모임질문 조회 시, question 이 null 이 아닌 경우(질문이 등록된 경우)만 조회하도록 수정합니다.
- 종료된 모임 질문 응답 시, 답변이 등록되지 않은 경우를 고려합니다.
- 활성화된 모임 질문 조건에 질문 등록 여부를 고려합니다.