### PR TITLE
[SAMBAD-224] 모임 질문 저장 시 현재 질문 조회 버그 수정

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionRepository.java
@@ -23,6 +23,8 @@ public interface MeetingQuestionRepository {
 
 	Optional<MeetingQuestion> findActiveOneByMeeting(Long meetingId);
 
+	Optional<MeetingQuestion> findRegisteredOneByMeeting(Long meetingId);
+
 	MostInactiveMeetingQuestionListResponse findMostInactiveList(Long meetingId);
 
 	FullInactiveMeetingQuestionListResponse findFullInactiveList(Long meetingId, Pageable pageable);

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionService.java
@@ -52,14 +52,14 @@ public class MeetingQuestionService {
 		MeetingMember nextTargetMember = meetingMemberService.getById(request.meetingMemberId());
 		loginMember.validateNextTarget(nextTargetMember);
 
-		Optional<MeetingQuestion> activeMeetingQuestion = findActiveMeetingQuestion(meetingId);
+		Optional<MeetingQuestion> registeredMeetingQuestion = findRegisteredMeetingQuestion(meetingId);
 		Question activeQuestion = questionService.getById(request.questionId());
 		validateNonDuplicateQuestion(meetingId, activeQuestion.getId());
 
 		Meeting meeting = loginMember.getMeeting();
 		MeetingQuestion nowMeetingQuestion = null;
-		if (activeMeetingQuestion.isPresent()) {
-			nowMeetingQuestion = activeMeetingQuestion.get();
+		if (registeredMeetingQuestion.isPresent()) {
+			nowMeetingQuestion = registeredMeetingQuestion.get();
 			nowMeetingQuestion.setQuestion(loginMember, activeQuestion);
 		} else {
 			nowMeetingQuestion = createActiveQuestion(meeting, loginMember, activeQuestion);
@@ -148,6 +148,10 @@ public class MeetingQuestionService {
 
 	private Optional<MeetingQuestion> findActiveMeetingQuestion(Long meetingId) {
 		return meetingQuestionRepository.findActiveOneByMeeting(meetingId);
+	}
+
+	private Optional<MeetingQuestion> findRegisteredMeetingQuestion(Long meetingId) {
+		return meetingQuestionRepository.findRegisteredOneByMeeting(meetingId);
 	}
 
 	private void validateNonDuplicateQuestion(Long meetingId, Long questionId) {

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/domain/MeetingQuestion.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/domain/MeetingQuestion.java
@@ -104,6 +104,7 @@ public class MeetingQuestion extends BaseTimeEntity {
 			throw new DuplicateMeetingQuestionException();
 		}
 		this.question = question;
+		this.meetingQuestionStatus = ACTIVE;
 		this.question.addMeetingQuestion(this);
 	}
 

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionRepositoryImpl.java
@@ -48,6 +48,11 @@ public class MeetingQuestionRepositoryImpl implements MeetingQuestionRepository 
 	}
 
 	@Override
+	public Optional<MeetingQuestion> findRegisteredOneByMeeting(Long meetingId) {
+		return meetingQuestionQueryRepository.findRegisteredMeetingQuestion(meetingId);
+	}
+
+	@Override
 	public MostInactiveMeetingQuestionListResponse findMostInactiveList(Long meetingId) {
 		return meetingQuestionQueryRepository.findMostInactiveList(meetingId);
 	}

--- a/src/main/java/org/depromeet/sambad/moring/question/domain/QuestionType.java
+++ b/src/main/java/org/depromeet/sambad/moring/question/domain/QuestionType.java
@@ -5,7 +5,7 @@ import org.depromeet.sambad.moring.question.presentation.exception.AnswerCountOu
 public enum QuestionType {
 	SINGLE_CHOICE, MULTIPLE_SHORT_CHOICE, MULTIPLE_DESCRIPTIVE_CHOICE;
 
-	private static final int MIN_ANSWER_COUNT = 1;
+	private static final int MIN_ANSWER_COUNT = 2;
 	private static final int MULTI_CHOICE_MAX_ANSWER_COUNT = 9;
 
 	public static void validateAnswerCount(QuestionType questionType, int answerCount) {


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- 현재 턴의 모임 질문 조회 시 ACTIVE 상태가 아닌 등록되기만 한 모임 질문을 조회해야 합니다.