### PR TITLE
[SAMBAD-247] 이벤트 만료 로직 추가

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/event/application/EventService.java
+++ b/src/main/java/org/depromeet/sambad/moring/event/application/EventService.java
@@ -42,7 +42,13 @@ public class EventService {
 	public PollingEventListResponse getActiveEvents(Long userId, Long meetingId) {
 		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
 		List<Event> events = eventRepository.findByUserIdAndMeetingIdAndStatus(userId, meetingId, EventStatus.ACTIVE);
-		return PollingEventListResponse.from(events);
+		events.forEach(Event::inactivateIfExpired);
+
+		List<Event> notExpiredEvents = events.stream()
+			.filter(Event::isActive)
+			.toList();
+
+		return PollingEventListResponse.from(notExpiredEvents);
 	}
 
 	private Event getEventById(Long eventId) {

--- a/src/main/java/org/depromeet/sambad/moring/event/domain/Event.java
+++ b/src/main/java/org/depromeet/sambad/moring/event/domain/Event.java
@@ -5,6 +5,9 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 import static org.depromeet.sambad.moring.event.domain.EventStatus.ACTIVE;
 import static org.depromeet.sambad.moring.event.domain.EventStatus.INACTIVE;
+import static org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion.*;
+
+import java.time.LocalDateTime;
 
 import org.depromeet.sambad.moring.common.domain.BaseTimeEntity;
 
@@ -32,21 +35,40 @@ public class Event extends BaseTimeEntity {
 
 	@Enumerated(STRING)
 	private EventType type;
+
 	@Enumerated(STRING)
 	private EventStatus status;
 
-	private Event(Long userId, Long meetingId, EventType type, EventStatus status) {
+	private LocalDateTime expiredAt;
+
+	private Event(Long userId, Long meetingId, EventType type, EventStatus status, LocalDateTime expiredAt) {
 		this.userId = userId;
 		this.meetingId = meetingId;
 		this.type = type;
 		this.status = status;
+		this.expiredAt = expiredAt;
 	}
 
 	public static Event publish(Long userId, Long meetingId, EventType type) {
-		return new Event(userId, meetingId, type, ACTIVE);
+		LocalDateTime expiredAt = LocalDateTime.now().plusHours(RESPONSE_TIME_LIMIT_HOURS);
+		return new Event(userId, meetingId, type, ACTIVE, expiredAt);
 	}
 
 	public void inactivate() {
 		this.status = INACTIVE;
+	}
+
+	public void inactivateIfExpired() {
+		if (isExpired()) {
+			inactivate();
+		}
+	}
+
+	private boolean isExpired() {
+		return LocalDateTime.now().isAfter(expiredAt);
+	}
+
+	public boolean isActive() {
+		return status == ACTIVE;
 	}
 }


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- 기존엔 모임원이 모두 답변하지 않아 질문이 종료되거나 타겟 멤버가 질문을 등록하지 않아도, 이벤트가 유지되었습니다.
  - 질문이 비활성화되는 시간인 4시간 이후 알림도 자동 만료되도록 합니다.

## 🔗 ISSUE 링크
- resolved [SAMBAD-247](https://www.notion.so/depromeet/08ae21ab08414e07bdd5f47104cecaeb?pvs=4)