### PR TITLE
[SAMBAD-248] 모임 목록 API에 모임명 정보 추가

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/event/application/EventService.java
+++ b/src/main/java/org/depromeet/sambad/moring/event/application/EventService.java
@@ -39,6 +39,7 @@ public class EventService {
 			.ifPresent(Event::inactivate);
 	}
 
+	@Transactional
 	public PollingEventListResponse getActiveEvents(Long userId, Long meetingId) {
 		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
 		List<Event> events = eventRepository.findByUserIdAndMeetingIdAndStatus(userId, meetingId, EventStatus.ACTIVE);

--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/response/MeetingResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/response/MeetingResponse.java
@@ -24,7 +24,7 @@ public record MeetingResponse(
 		@Schema(description = "모임 ID", example = "1", requiredMode = REQUIRED)
 		Long meetingId,
 
-		@Schema(description = "모임명", example = "1", requiredMode = REQUIRED)
+		@Schema(description = "모임명", example = "삼밧드의 모험", requiredMode = REQUIRED)
 		String name
 	) {
 	}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/response/MeetingResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/response/MeetingResponse.java
@@ -9,14 +9,23 @@ import org.depromeet.sambad.moring.meeting.meeting.domain.Meeting;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record MeetingResponse(
-	@Schema(description = "모임 ID 목록", example = "[1, 2, 3]", requiredMode = REQUIRED)
-	List<Long> meetingIds
+	@Schema(description = "가입 되어 있는 모임의 정보 목록", requiredMode = REQUIRED)
+	List<MeetingResponseDetail> meetings
 ) {
 	public static MeetingResponse from(List<Meeting> meetings) {
 		return new MeetingResponse(
 			meetings.stream()
-				.map(Meeting::getId)
+				.map(meeting -> new MeetingResponseDetail(meeting.getId(), meeting.getName()))
 				.toList()
 		);
+	}
+
+	public record MeetingResponseDetail(
+		@Schema(description = "모임 ID", example = "1", requiredMode = REQUIRED)
+		Long meetingId,
+
+		@Schema(description = "모임명", example = "1", requiredMode = REQUIRED)
+		String name
+	) {
 	}
 }


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- 2차 MVP 기준, 모임 목록에 모임명이 표시되어야 합니다.
- 마이그레이션 이슈를 고려하여, 미리 모임명 필드를 추가합니다.

## 🔗 ISSUE 링크
- resolved [SAMBAD-248](https://www.notion.so/depromeet/API-875d107302e7496fa761f5f077349613?pvs=4)