### PR TITLE
[SAMBAD-249] 질문 활성 및 비활성화 체크 스케줄러 추가, 질문 조회 로직 리팩토링

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/common/config/SchedulingConfig.java
+++ b/src/main/java/org/depromeet/sambad/moring/common/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package org.depromeet.sambad.moring.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/org/depromeet/sambad/moring/event/application/EventRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/event/application/EventRepository.java
@@ -17,4 +17,6 @@ public interface EventRepository {
 	Optional<Event> findFirstByUserIdAndMeetingIdAndStatusAndType(
 		Long userId, Long meetingId, EventStatus eventStatus, EventType type
 	);
+
+	List<Event> findByMeetingIdAndStatusAndType(Long meetingId, EventStatus eventStatus, EventType eventType);
 }

--- a/src/main/java/org/depromeet/sambad/moring/event/application/EventService.java
+++ b/src/main/java/org/depromeet/sambad/moring/event/application/EventService.java
@@ -1,9 +1,10 @@
 package org.depromeet.sambad.moring.event.application;
 
+import static org.depromeet.sambad.moring.event.domain.EventStatus.*;
+
 import java.util.List;
 
 import org.depromeet.sambad.moring.event.domain.Event;
-import org.depromeet.sambad.moring.event.domain.EventStatus;
 import org.depromeet.sambad.moring.event.domain.EventType;
 import org.depromeet.sambad.moring.event.presentation.excepiton.NotFoundEventException;
 import org.depromeet.sambad.moring.event.presentation.response.PollingEventListResponse;
@@ -12,7 +13,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EventService {
@@ -21,7 +24,11 @@ public class EventService {
 
 	@Transactional
 	public void publish(Long userId, Long meetingId, EventType type) {
-		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
+		if (meetingMemberValidator.isNotMemberOfMeeting(userId, meetingId)) {
+			log.warn("User is not member of meeting. userId: {}, meetingId: {}", userId, meetingId);
+			return;
+		}
+
 		Event event = Event.publish(userId, meetingId, type);
 		eventRepository.save(event);
 	}
@@ -35,14 +42,14 @@ public class EventService {
 
 	@Transactional
 	public void inactivateLastEventByType(Long userId, Long meetingId, EventType type) {
-		eventRepository.findFirstByUserIdAndMeetingIdAndStatusAndType(userId, meetingId, EventStatus.ACTIVE, type)
+		eventRepository.findFirstByUserIdAndMeetingIdAndStatusAndType(userId, meetingId, ACTIVE, type)
 			.ifPresent(Event::inactivate);
 	}
 
 	@Transactional
 	public PollingEventListResponse getActiveEvents(Long userId, Long meetingId) {
 		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
-		List<Event> events = eventRepository.findByUserIdAndMeetingIdAndStatus(userId, meetingId, EventStatus.ACTIVE);
+		List<Event> events = eventRepository.findByUserIdAndMeetingIdAndStatus(userId, meetingId, ACTIVE);
 		events.forEach(Event::inactivateIfExpired);
 
 		List<Event> notExpiredEvents = events.stream()
@@ -50,6 +57,12 @@ public class EventService {
 			.toList();
 
 		return PollingEventListResponse.from(notExpiredEvents);
+	}
+
+	@Transactional
+	public void inactivateLastEventsOfAllMemberByType(Long meetingId, EventType eventType) {
+		List<Event> events = eventRepository.findByMeetingIdAndStatusAndType(meetingId, ACTIVE, eventType);
+		events.forEach(Event::inactivate);
 	}
 
 	private Event getEventById(Long eventId) {

--- a/src/main/java/org/depromeet/sambad/moring/event/domain/Event.java
+++ b/src/main/java/org/depromeet/sambad/moring/event/domain/Event.java
@@ -1,10 +1,9 @@
 package org.depromeet.sambad.moring.event.domain;
 
-import static jakarta.persistence.EnumType.STRING;
-import static jakarta.persistence.GenerationType.IDENTITY;
-import static lombok.AccessLevel.PROTECTED;
-import static org.depromeet.sambad.moring.event.domain.EventStatus.ACTIVE;
-import static org.depromeet.sambad.moring.event.domain.EventStatus.INACTIVE;
+import static jakarta.persistence.EnumType.*;
+import static jakarta.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
+import static org.depromeet.sambad.moring.event.domain.EventStatus.*;
 import static org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion.*;
 
 import java.time.LocalDateTime;
@@ -50,7 +49,7 @@ public class Event extends BaseTimeEntity {
 	}
 
 	public static Event publish(Long userId, Long meetingId, EventType type) {
-		LocalDateTime expiredAt = LocalDateTime.now().plusHours(RESPONSE_TIME_LIMIT_HOURS);
+		LocalDateTime expiredAt = LocalDateTime.now().plusSeconds(RESPONSE_TIME_LIMIT_SECONDS);
 		return new Event(userId, meetingId, type, ACTIVE, expiredAt);
 	}
 

--- a/src/main/java/org/depromeet/sambad/moring/event/infrastructure/EventJpaRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/event/infrastructure/EventJpaRepository.java
@@ -14,4 +14,6 @@ public interface EventJpaRepository extends JpaRepository<Event, Long> {
 	Optional<Event> findFirstByUserIdAndMeetingIdAndStatusAndTypeOrderByIdDesc(
 		Long userId, Long meetingId, EventStatus eventStatus, EventType type
 	);
+
+	List<Event> findByMeetingIdAndStatusAndType(Long meetingId, EventStatus eventStatus, EventType eventType);
 }

--- a/src/main/java/org/depromeet/sambad/moring/event/infrastructure/EventRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moring/event/infrastructure/EventRepositoryImpl.java
@@ -35,6 +35,11 @@ public class EventRepositoryImpl implements EventRepository {
 	}
 
 	@Override
+	public List<Event> findByMeetingIdAndStatusAndType(Long meetingId, EventStatus eventStatus, EventType eventType) {
+		return eventJpaRepository.findByMeetingIdAndStatusAndType(meetingId, eventStatus, eventType);
+	}
+
+	@Override
 	public void save(Event event) {
 		eventJpaRepository.save(event);
 	}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMemberValidator.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMemberValidator.java
@@ -53,14 +53,18 @@ public class MeetingMemberValidator {
 	}
 
 	public void validateUserIsMemberOfMeeting(Long userId, Long meetingId) {
-		if (!meetingMemberRepository.isUserMemberOfMeeting(userId, meetingId)) {
+		if (isNotMemberOfMeeting(userId, meetingId)) {
 			throw new UserNotMemberOfMeetingException();
 		}
 	}
 
 	public void validateMemberIsMemberOfMeeting(Long memberId, Long meetingId) {
-		if (!meetingMemberRepository.isUserMemberOfMeeting(memberId, meetingId)) {
+		if (isNotMemberOfMeeting(memberId, meetingId)) {
 			throw new MeetingMemberNotFoundException();
 		}
+	}
+
+	public boolean isNotMemberOfMeeting(Long userId, Long meetingId) {
+		return !meetingMemberRepository.isUserMemberOfMeeting(userId, meetingId);
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionRepository.java
@@ -1,11 +1,12 @@
 package org.depromeet.sambad.moring.meeting.question.application;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
 import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
-import org.depromeet.sambad.moring.meeting.question.presentation.response.ActiveMeetingQuestionResponse;
+import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestionStatus;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.FullInactiveMeetingQuestionListResponse;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.MeetingQuestionStatisticsDetail;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.MostInactiveMeetingQuestionListResponse;
@@ -19,11 +20,7 @@ public interface MeetingQuestionRepository {
 
 	boolean existsByQuestion(Long meetingId, Long questionId);
 
-	ActiveMeetingQuestionResponse findActiveOneByMeeting(Long meetingId, Long loginMeetingMemberId);
-
 	Optional<MeetingQuestion> findActiveOneByMeeting(Long meetingId);
-
-	Optional<MeetingQuestion> findRegisteredOneByMeeting(Long meetingId);
 
 	MostInactiveMeetingQuestionListResponse findMostInactiveList(Long meetingId);
 
@@ -34,4 +31,10 @@ public interface MeetingQuestionRepository {
 	List<MeetingQuestionStatisticsDetail> findStatistics(Long meetingQuestionId);
 
 	List<MeetingMember> findMeetingMembersByMeetingQuestionId(Long meetingQuestionId);
+
+	List<MeetingQuestion> findAllByStatusAndExpiredAtBefore(MeetingQuestionStatus status, LocalDateTime now);
+
+	Optional<MeetingQuestion> findFirstByMeetingIdAndStatus(Long meetingId, MeetingQuestionStatus status);
+
+	boolean isAnswered(Long meetingQuestionId, Long meetingMemberId);
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionStatusCheckScheduler.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionStatusCheckScheduler.java
@@ -1,0 +1,71 @@
+package org.depromeet.sambad.moring.meeting.question.application;
+
+import static java.time.LocalDateTime.*;
+import static org.depromeet.sambad.moring.event.domain.EventType.*;
+import static org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestionStatus.*;
+
+import java.util.List;
+
+import org.depromeet.sambad.moring.event.application.EventService;
+import org.depromeet.sambad.moring.meeting.meeting.domain.Meeting;
+import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class MeetingQuestionStatusCheckScheduler {
+
+	private final MeetingQuestionRepository meetingQuestionRepository;
+	private final EventService eventService;
+
+	@Scheduled(fixedDelay = 1000 * 5)
+	@Transactional
+	public void inactivate() {
+		// 활성 상태이지만 만료 시간이 지나 INACTIVE 상태가 되어야 하는 질문 목록 조회
+		List<MeetingQuestion> targets = meetingQuestionRepository.findAllByStatusAndExpiredAtBefore(ACTIVE, now());
+
+		// 질문 비활성화 처리
+		targets.forEach(MeetingQuestion::updateStatusToInactive);
+
+		// 해당 모임의 다음 질문 활성화 처리 및 이벤트 발행
+		targets.stream()
+			.map(MeetingQuestion::getMeeting)
+			.forEach(this::activate);
+
+		// 결과 로깅
+		logResults(targets);
+	}
+
+	private void activate(Meeting meeting) {
+		Long meetingId = meeting.getId();
+
+		meetingQuestionRepository.findFirstByMeetingIdAndStatus(meetingId, NOT_STARTED)
+			.ifPresent(targetMeetingQuestion -> {
+				targetMeetingQuestion.updateStatusToActive(now());
+				reissueTargetMemberEvent(targetMeetingQuestion);
+				log.info("Activated not started meeting question. {}", targetMeetingQuestion.getId());
+			});
+	}
+
+	private void reissueTargetMemberEvent(MeetingQuestion target) {
+		Long meetingId = target.getMeeting().getId();
+		Long targetMemberUserId = target.getTargetMember().getUser().getId();
+
+		eventService.inactivateLastEventsOfAllMemberByType(meetingId, QUESTION_REGISTERED);
+		eventService.inactivateLastEventByType(targetMemberUserId, meetingId, TARGET_MEMBER);
+		eventService.publish(targetMemberUserId, meetingId, TARGET_MEMBER);
+	}
+
+	private void logResults(List<MeetingQuestion> targets) {
+		if (!targets.isEmpty()) {
+			List<Long> inactivatedIds = targets.stream().map(MeetingQuestion::getId).toList();
+			log.info("Inactivated {} meeting questions. {}", targets.size(), inactivatedIds);
+		}
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionJpaRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionJpaRepository.java
@@ -1,8 +1,11 @@
 package org.depromeet.sambad.moring.meeting.question.infrastructure;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
+import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestionStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MeetingQuestionJpaRepository extends JpaRepository<MeetingQuestion, Long> {
@@ -10,4 +13,9 @@ public interface MeetingQuestionJpaRepository extends JpaRepository<MeetingQuest
 	boolean existsByMeetingIdAndQuestionId(Long meetingId, Long questionId);
 
 	Optional<MeetingQuestion> findByMeetingIdAndId(Long meetingId, Long meetingQuestionId);
+
+	List<MeetingQuestion> findAllByStatusAndExpiredAtBefore(MeetingQuestionStatus status, LocalDateTime now);
+
+	Optional<MeetingQuestion> findFirstByMeetingIdAndStatusOrderByStartTime(
+		Long meetingId, MeetingQuestionStatus status);
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionRepositoryImpl.java
@@ -1,12 +1,15 @@
 package org.depromeet.sambad.moring.meeting.question.infrastructure;
 
+import static org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestionStatus.*;
+
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
 import org.depromeet.sambad.moring.meeting.question.application.MeetingQuestionRepository;
 import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
-import org.depromeet.sambad.moring.meeting.question.presentation.response.ActiveMeetingQuestionResponse;
+import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestionStatus;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.FullInactiveMeetingQuestionListResponse;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.MeetingQuestionStatisticsDetail;
 import org.depromeet.sambad.moring.meeting.question.presentation.response.MostInactiveMeetingQuestionListResponse;
@@ -38,18 +41,8 @@ public class MeetingQuestionRepositoryImpl implements MeetingQuestionRepository 
 	}
 
 	@Override
-	public ActiveMeetingQuestionResponse findActiveOneByMeeting(Long meetingId, Long loginMeetingMemberId) {
-		return meetingQuestionQueryRepository.findActiveOneByMeeting(meetingId, loginMeetingMemberId);
-	}
-
-	@Override
 	public Optional<MeetingQuestion> findActiveOneByMeeting(Long meetingId) {
-		return meetingQuestionQueryRepository.findActiveOneByMeeting(meetingId);
-	}
-
-	@Override
-	public Optional<MeetingQuestion> findRegisteredOneByMeeting(Long meetingId) {
-		return meetingQuestionQueryRepository.findRegisteredMeetingQuestion(meetingId);
+		return meetingQuestionJpaRepository.findFirstByMeetingIdAndStatusOrderByStartTime(meetingId, ACTIVE);
 	}
 
 	@Override
@@ -75,5 +68,20 @@ public class MeetingQuestionRepositoryImpl implements MeetingQuestionRepository 
 	@Override
 	public List<MeetingMember> findMeetingMembersByMeetingQuestionId(Long meetingQuestionId) {
 		return meetingQuestionQueryRepository.findMeetingMembersByMeetingQuestionId(meetingQuestionId);
+	}
+
+	@Override
+	public List<MeetingQuestion> findAllByStatusAndExpiredAtBefore(MeetingQuestionStatus status, LocalDateTime now) {
+		return meetingQuestionJpaRepository.findAllByStatusAndExpiredAtBefore(status, now);
+	}
+
+	@Override
+	public Optional<MeetingQuestion> findFirstByMeetingIdAndStatus(Long meetingId, MeetingQuestionStatus status) {
+		return meetingQuestionJpaRepository.findFirstByMeetingIdAndStatusOrderByStartTime(meetingId, status);
+	}
+
+	@Override
+	public boolean isAnswered(Long meetingQuestionId, Long meetingMemberId) {
+		return meetingQuestionQueryRepository.isAnswered(meetingQuestionId, meetingMemberId);
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/MeetingQuestionController.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/MeetingQuestionController.java
@@ -108,11 +108,9 @@ public class MeetingQuestionController {
 		@UserId Long userId,
 		@Parameter(description = "모임 ID", example = "1", required = true) @PathVariable("meetingId") Long meetingId
 	) {
-		ActiveMeetingQuestionResponse activeOne = meetingQuestionService.findActiveOne(userId, meetingId);
-		if (activeOne == null) {
-			return ResponseEntity.noContent().build();
-		}
-		return ResponseEntity.ok(activeOne);
+		return meetingQuestionService.findActiveOne(userId, meetingId)
+			.map(ResponseEntity::ok)
+			.orElse(ResponseEntity.noContent().build());
 	}
 
 	@Operation(summary = "진행 중인 모임의 릴레이 질문과 답안 옵션 조회", description = "- 질문과 질문의 답변 목록을 함께 반환합니다.\n"


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- `MeetingQuestionStatusCheckScheduler`를 추가합니다.
  - **5초 간격**으로, 만료되어 종료되어야 하는 질문이 존재하는지 검사합니다.
  - 만약 질문이 종료되었다면, 해당 모임의 다음 질문을 활성화합니다.
- 질문의 만료 여부를 확인할 수 있는 `expired_at` 칼럼을 추가합니다.
  - 질문마다 만료 시간이 달라질 수 있는 점, 쿼리 간결성, 테스트 용으로 특정 질문만 만료 시간을 줄일 수 있는 점 등을 고려하여 추가했습니다.
- `meeting_question.meeting_question_status` -> `meeting_question.status` 명칭을 변경합니다.
- 활성화된 질문 조회 로직을 리팩토링합니다.
  - 주로 `status`만 확인하면 되도록 변경했습니다.
- `RESPONSE_TIME_LIMIT_HOURS`-> `RESPONSE_TIME_LIMIT_SECONDS`로 변경했습니다.
  - 확장성을 위해, 특정 수치를 상수화할 땐 작은 단위인게 좋습니다 👍

## 🔗 ISSUE 링크
- resolved [SAMBAD-249](https://www.notion.so/depromeet/d8bc1933bdc0466996d661040b81d506?pvs=4)