### PR TITLE
[SAMBAD-194] `나와 같은 답변 선택 모임원` 조회 시, 본인이 제외되도록 수정

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/application/MeetingAnswerResultService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/application/MeetingAnswerResultService.java
@@ -51,6 +51,9 @@ public class MeetingAnswerResultService {
 		List<MeetingMember> members = meetingAnswerRepository.findMeetingMembersSelectWith(
 			meetingQuestionId, MeetingAnswer.getDistinctAnswerIds(meetingAnswers));
 
+		// 자기 자신은 제외
+		members.remove(meetingMember);
+
 		return SelectedAnswerResponse.from(members, meetingAnswers);
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/application/MeetingAnswerResultService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/application/MeetingAnswerResultService.java
@@ -48,11 +48,11 @@ public class MeetingAnswerResultService {
 		List<MeetingAnswer> meetingAnswers = meetingAnswerRepository.findByMeetingQuestionIdAndMeetingMemberId(
 			meetingQuestionId, meetingMember.getId());
 
-		List<MeetingMember> members = meetingAnswerRepository.findMeetingMembersSelectWith(
-			meetingQuestionId, MeetingAnswer.getDistinctAnswerIds(meetingAnswers));
-
-		// 자기 자신은 제외
-		members.remove(meetingMember);
+		List<Long> answerIds = MeetingAnswer.getDistinctAnswerIds(meetingAnswers);
+		List<MeetingMember> members = meetingAnswerRepository.findMeetingMembersSelectWith(meetingQuestionId, answerIds)
+			.stream()
+			.filter(member -> member.isNotEqualMember(meetingMember))
+			.toList();
 
 		return SelectedAnswerResponse.from(members, meetingAnswers);
 	}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/application/MeetingAnswerResultService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/application/MeetingAnswerResultService.java
@@ -43,15 +43,15 @@ public class MeetingAnswerResultService {
 
 	public SelectedAnswerResponse getSelectedSameAnswer(Long userId, Long meetingId, Long meetingQuestionId) {
 		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
-		MeetingMember meetingMember = meetingMemberService.getByUserIdAndMeetingId(userId, meetingId);
+		MeetingMember meetingMemberOfRequestedUser = meetingMemberService.getByUserIdAndMeetingId(userId, meetingId);
 
 		List<MeetingAnswer> meetingAnswers = meetingAnswerRepository.findByMeetingQuestionIdAndMeetingMemberId(
-			meetingQuestionId, meetingMember.getId());
+			meetingQuestionId, meetingMemberOfRequestedUser.getId());
 
 		List<Long> answerIds = MeetingAnswer.getDistinctAnswerIds(meetingAnswers);
 		List<MeetingMember> members = meetingAnswerRepository.findMeetingMembersSelectWith(meetingQuestionId, answerIds)
 			.stream()
-			.filter(member -> member.isNotEqualMember(meetingMember))
+			.filter(meetingMemberOfRequestedUser::isNotEqualMemberWith)
 			.toList();
 
 		return SelectedAnswerResponse.from(members, meetingAnswers);

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerQueryRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerQueryRepository.java
@@ -59,7 +59,10 @@ public class MeetingAnswerQueryRepository {
 		}
 
 		return queryFactory.selectFrom(meetingAnswer)
-			.where(meetingAnswer.answer.id.eq(mostSelectedAnswerId))
+			.where(
+				meetingAnswer.answer.id.eq(mostSelectedAnswerId),
+				meetingAnswer.meetingQuestion.id.eq(meetingQuestionId)
+			)
 			.fetch();
 	}
 

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/presentation/response/SelectedAnswerResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/presentation/response/SelectedAnswerResponse.java
@@ -15,10 +15,10 @@ public record SelectedAnswerResponse(
 	@Schema(description = "답변 내용", example = "[\"토마토\"]", requiredMode = REQUIRED)
 	List<String> content,
 
-	@Schema(description = "답변 수", example = "3", requiredMode = REQUIRED)
+	@Schema(description = "해당 모임을 선택한 모임원 수", example = "3", requiredMode = REQUIRED)
 	int count,
 
-	@Schema(description = "선택한 멤버들", requiredMode = REQUIRED)
+	@Schema(description = "선택한 모임원 목록", requiredMode = REQUIRED)
 	List<MeetingMemberListResponseDetail> selectedMembers
 ) {
 	public static SelectedAnswerResponse from(List<MeetingMember> members, List<MeetingAnswer> meetingAnswers) {
@@ -27,7 +27,7 @@ public record SelectedAnswerResponse(
 				.map(MeetingAnswer::getAnswerContent)
 				.distinct()
 				.toList(),
-			meetingAnswers.size(),
+			members.size(),
 			MeetingMemberListResponse.from(members).contents()
 		);
 	}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMember.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMember.java
@@ -156,4 +156,8 @@ public class MeetingMember extends BaseTimeEntity implements Comparable<MeetingM
 			throw new InvalidMeetingMemberTargetException();
 		}
 	}
+
+	public boolean isNotEqualMember(MeetingMember meetingMember) {
+		return !Objects.equals(this.getId(), meetingMember.getId());
+	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMember.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMember.java
@@ -157,7 +157,7 @@ public class MeetingMember extends BaseTimeEntity implements Comparable<MeetingM
 		}
 	}
 
-	public boolean isNotEqualMember(MeetingMember meetingMember) {
+	public boolean isNotEqualMemberWith(MeetingMember meetingMember) {
 		return !Objects.equals(this.getId(), meetingMember.getId());
 	}
 }


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- `나와 같은 답변 선택 모임원` 조회 시, 본인이 제외되도록 수정합니다.
- `SelectedAnswerResponse.count`가 선택한 모임원 수로 표시되도록 수정합니다.

## 🔗 ISSUE 링크
- resolved [SAMBAD-194](https://www.notion.so/depromeet/76d3bfb6f5da4571957872ff5299938d?pvs=4)