### PR TITLE
[SAMBAD-255] 종료된 모임 질문의 경우 참여율 계산 로직 수정

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/domain/Meeting.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/domain/Meeting.java
@@ -79,18 +79,11 @@ public class Meeting extends BaseTimeEntity {
 			});
 	}
 
-	public int getTotalMemberCount() {
+	public Integer getTotalMemberCount() {
 		return meetingMembers.size();
 	}
 
 	public int getQuestionNumber(MeetingQuestion meetingQuestion) {
 		return meetingQuestions.indexOf(meetingQuestion) + 1;
-	}
-
-	public double calculateEngagementRate(MeetingQuestion meetingQuestion) {
-		if (getTotalMemberCount() == 0)
-			return 0;
-		double engagementRate = ((double)meetingQuestion.getResponseCount() / getTotalMemberCount()) * 100;
-		return Math.round(engagementRate);
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberService.java
@@ -115,7 +115,7 @@ public class MeetingMemberService {
 
 		if (meetingMemberRepository.isCountOfMembersIsOne(meetingId)) {
 			MeetingQuestion activeMeetingQuestion = MeetingQuestion.createActiveMeetingQuestion(
-				meeting, meetingMember, null, LocalDateTime.now());
+				meeting, meetingMember, null, LocalDateTime.now(), meeting.getTotalMemberCount());
 
 			meetingQuestionRepository.save(activeMeetingQuestion);
 			eventService.publish(meetingMember.getUser().getId(), meetingId, TARGET_MEMBER);

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberService.java
@@ -45,6 +45,24 @@ public class MeetingMemberService {
 	private final MeetingMemberHobbyRepository meetingMemberHobbyRepository;
 	private final EventService eventService;
 
+	@Transactional
+	public MeetingMemberPersistResponse registerMeetingMember(
+		Long userId, String code, MeetingMemberPersistRequest request
+	) {
+		Meeting meeting = meetingRepository.findByCode(MeetingCode.from(code))
+			.orElseThrow(MeetingNotFoundException::new);
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(NotFoundUserException::new);
+
+		MeetingMember meetingMember = validateAndCreateMember(userId, request, meeting, user);
+		addHobbies(meetingMember, request);
+
+		createMeetingQuestionIfFirstMeetingMember(meeting, meetingMember);
+
+		return MeetingMemberPersistResponse.from(meetingMember);
+	}
+
 	public MeetingMemberListResponse getMeetingMembers(Long userId, Long meetingId) {
 		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
 
@@ -54,10 +72,6 @@ public class MeetingMemberService {
 	public MeetingMember getByUserIdAndMeetingId(Long userId, Long meetingId) {
 		return meetingMemberRepository.findByUserIdAndMeetingId(userId, meetingId)
 			.orElseThrow(MeetingMemberNotFoundException::new);
-	}
-
-	public boolean isNotEnterAnyMeeting(Long userId) {
-		return meetingMemberRepository.findByUserId(userId).isEmpty();
 	}
 
 	public MeetingMember getById(Long meetingMemberId) {
@@ -77,36 +91,6 @@ public class MeetingMemberService {
 		return MeetingMemberResponse.from(getByUserIdAndMeetingId(userId, meetingId));
 	}
 
-	@Transactional
-	public MeetingMemberPersistResponse registerMeetingMember(
-		Long userId, String code, MeetingMemberPersistRequest request
-	) {
-		Meeting meeting = meetingRepository.findByCode(MeetingCode.from(code))
-			.orElseThrow(MeetingNotFoundException::new);
-
-		User user = userRepository.findById(userId)
-			.orElseThrow(NotFoundUserException::new);
-
-		MeetingMember meetingMember = validateAndCreateMember(userId, request, meeting, user);
-		addHobbies(meetingMember, request);
-
-		createMeetingQuestionIfFirstMeetingMember(meeting, meetingMember);
-
-		return MeetingMemberPersistResponse.from(meetingMember);
-	}
-
-	private void createMeetingQuestionIfFirstMeetingMember(Meeting meeting, MeetingMember meetingMember) {
-		Long meetingId = meeting.getId();
-
-		if (meetingMemberRepository.isCountOfMembersIsOne(meetingId)) {
-			MeetingQuestion activeMeetingQuestion = MeetingQuestion.createActiveMeetingQuestion(
-				meeting, meetingMember, null, LocalDateTime.now());
-
-			meetingQuestionRepository.save(activeMeetingQuestion);
-			eventService.publish(meetingMember.getUser().getId(), meetingId, TARGET_MEMBER);
-		}
-	}
-
 	public MeetingMemberListResponseDetail getRandomMeetingMember(Long userId, Long meetingId,
 		List<Long> excludeMemberIds) {
 		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
@@ -120,6 +104,22 @@ public class MeetingMemberService {
 
 		MeetingMember randomMember = meetingMemberRandomGenerator.generate(nextTargetMembers);
 		return MeetingMemberListResponseDetail.from(randomMember);
+	}
+
+	public boolean isNotEnterAnyMeeting(Long userId) {
+		return meetingMemberRepository.findByUserId(userId).isEmpty();
+	}
+
+	private void createMeetingQuestionIfFirstMeetingMember(Meeting meeting, MeetingMember meetingMember) {
+		Long meetingId = meeting.getId();
+
+		if (meetingMemberRepository.isCountOfMembersIsOne(meetingId)) {
+			MeetingQuestion activeMeetingQuestion = MeetingQuestion.createActiveMeetingQuestion(
+				meeting, meetingMember, null, LocalDateTime.now());
+
+			meetingQuestionRepository.save(activeMeetingQuestion);
+			eventService.publish(meetingMember.getUser().getId(), meetingId, TARGET_MEMBER);
+		}
 	}
 
 	private MeetingMember validateAndCreateMember(

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionService.java
@@ -74,7 +74,7 @@ public class MeetingQuestionService {
 			eventService.publish(member.getUser().getId(), meetingId, QUESTION_REGISTERED));
 
 		MeetingQuestion nextMeetingQuestion = MeetingQuestion.createNextMeetingQuestion(
-			meeting, nextTargetMember, currentMeetingQuestion.getNextStartTime());
+			meeting, nextTargetMember, currentMeetingQuestion.getNextStartTime(), meeting.getTotalMemberCount());
 		meetingQuestionRepository.save(nextMeetingQuestion);
 
 		return CurrentMeetingQuestionResponse.questionRegisteredOf(currentMeetingQuestion, false);
@@ -83,7 +83,7 @@ public class MeetingQuestionService {
 	@Transactional
 	public MeetingQuestion createActiveQuestion(Meeting meeting, MeetingMember targetMember, Question activeQuestion) {
 		MeetingQuestion activeMeetingQuestion = MeetingQuestion.createActiveMeetingQuestion(meeting, targetMember,
-			activeQuestion, LocalDateTime.now(clock));
+			activeQuestion, LocalDateTime.now(clock), meeting.getTotalMemberCount());
 		return meetingQuestionRepository.save(activeMeetingQuestion);
 	}
 

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionStatusCheckScheduler.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionStatusCheckScheduler.java
@@ -24,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 public class MeetingQuestionStatusCheckScheduler {
 
 	private final MeetingQuestionRepository meetingQuestionRepository;
+
 	private final EventService eventService;
 
 	@Scheduled(fixedDelay = 10 * 1000)

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/domain/MeetingQuestion.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/domain/MeetingQuestion.java
@@ -66,7 +66,7 @@ public class MeetingQuestion extends BaseTimeEntity {
 
 	private LocalDateTime expiredAt;
 
-	private Integer totalMemberCount; // 모임 질문 종료 시점의 모임원 수
+	private int totalMemberCount; // 모임 질문 종료 시점의 모임원 수
 
 	@OneToMany(mappedBy = "meetingQuestion", fetch = FetchType.LAZY)
 	private List<MeetingAnswer> memberAnswers = new ArrayList<>();
@@ -78,7 +78,8 @@ public class MeetingQuestion extends BaseTimeEntity {
 		Question question,
 		LocalDateTime now,
 		MeetingQuestionStatus status,
-		LocalDateTime expiredAt
+		LocalDateTime expiredAt,
+		int totalMemberCount
 	) {
 		this.meeting = meeting;
 		this.targetMember = targetMember;
@@ -86,7 +87,7 @@ public class MeetingQuestion extends BaseTimeEntity {
 		this.startTime = now;
 		this.status = status;
 		this.expiredAt = expiredAt;
-		this.totalMemberCount = null;
+		this.totalMemberCount = totalMemberCount;
 
 		meeting.addMeetingQuestion(this);
 		targetMember.addMeetingQuestion(this);
@@ -96,17 +97,18 @@ public class MeetingQuestion extends BaseTimeEntity {
 	}
 
 	public static MeetingQuestion createActiveMeetingQuestion(
-		Meeting meeting, MeetingMember targetMember, Question activeQuestion, LocalDateTime now
+		Meeting meeting, MeetingMember targetMember, Question activeQuestion, LocalDateTime now, int totalMemberCount
 	) {
 		LocalDateTime expiredAt = now.plusSeconds(RESPONSE_TIME_LIMIT_SECONDS);
-		return new MeetingQuestion(meeting, targetMember, activeQuestion, now, ACTIVE, expiredAt);
+		return new MeetingQuestion(meeting, targetMember, activeQuestion, now, ACTIVE, expiredAt, totalMemberCount);
 	}
 
 	public static MeetingQuestion createNextMeetingQuestion(
-		Meeting meeting, MeetingMember targetMember, LocalDateTime startTime
+		Meeting meeting, MeetingMember targetMember, LocalDateTime startTime, int totalMemberCount
 	) {
 		LocalDateTime expiredAt = startTime.plusSeconds(RESPONSE_TIME_LIMIT_SECONDS);
-		return new MeetingQuestion(meeting, targetMember, null, startTime, NOT_STARTED, expiredAt);
+		return new MeetingQuestion(meeting, targetMember, null, startTime, NOT_STARTED, expiredAt,
+			totalMemberCount);
 	}
 
 	public void addMeetingAnswer(MeetingAnswer meetingAnswer) {

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/domain/MeetingQuestion.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/domain/MeetingQuestion.java
@@ -158,9 +158,9 @@ public class MeetingQuestion extends BaseTimeEntity {
 	}
 
 	public double calculateEngagementRate() {
-		if (getTotalMemberCount() == 0)
-			return 0;
 		Integer totalMemberCount = (status == INACTIVE) ? this.totalMemberCount : this.meeting.getTotalMemberCount();
+		if (totalMemberCount == 0)
+			return 0;
 		double engagementRate = ((double)getResponseCount() / totalMemberCount) * 100;
 		return Math.round(engagementRate);
 	}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/domain/MeetingQuestion.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/domain/MeetingQuestion.java
@@ -123,6 +123,10 @@ public class MeetingQuestion extends BaseTimeEntity {
 	}
 
 	public void updateStatusToInactive() {
+		if (this.status == INACTIVE) {
+			LoggingUtils.error("다음 MeetingQuestion 의 비활성화를 시도하였으나, 이미 비활성화된 질문입니다. meetingQuestionId : " + id);
+			return;
+		}
 		this.status = MeetingQuestionStatus.INACTIVE;
 		this.totalMemberCount = meeting.getTotalMemberCount();
 	}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/domain/MeetingQuestion.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/domain/MeetingQuestion.java
@@ -66,6 +66,8 @@ public class MeetingQuestion extends BaseTimeEntity {
 
 	private LocalDateTime expiredAt;
 
+	private Integer totalMemberCount; // 모임 질문 종료 시점의 모임원 수
+
 	@OneToMany(mappedBy = "meetingQuestion", fetch = FetchType.LAZY)
 	private List<MeetingAnswer> memberAnswers = new ArrayList<>();
 
@@ -84,6 +86,7 @@ public class MeetingQuestion extends BaseTimeEntity {
 		this.startTime = now;
 		this.status = status;
 		this.expiredAt = expiredAt;
+		this.totalMemberCount = null;
 
 		meeting.addMeetingQuestion(this);
 		targetMember.addMeetingQuestion(this);
@@ -121,6 +124,7 @@ public class MeetingQuestion extends BaseTimeEntity {
 
 	public void updateStatusToInactive() {
 		this.status = MeetingQuestionStatus.INACTIVE;
+		this.totalMemberCount = meeting.getTotalMemberCount();
 	}
 
 	public void updateStatusToActive(LocalDateTime startTime) {
@@ -151,6 +155,14 @@ public class MeetingQuestion extends BaseTimeEntity {
 
 	public LocalDateTime getNextStartTime() {
 		return startTime.plusSeconds(RESPONSE_TIME_LIMIT_SECONDS);
+	}
+
+	public double calculateEngagementRate() {
+		if (getTotalMemberCount() == 0)
+			return 0;
+		Integer totalMemberCount = (status == INACTIVE) ? this.totalMemberCount : this.meeting.getTotalMemberCount();
+		double engagementRate = ((double)getResponseCount() / totalMemberCount) * 100;
+		return Math.round(engagementRate);
 	}
 
 	public void validateNotFinished(LocalDateTime now) {

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/response/CurrentMeetingQuestionResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/response/CurrentMeetingQuestionResponse.java
@@ -75,7 +75,7 @@ public record CurrentMeetingQuestionResponse(
 			.questionNumber(meeting.getQuestionNumber(meetingQuestion))
 			.totalMeetingMemberCount(meeting.getTotalMemberCount())
 			.responseCount(meetingQuestion.getResponseCount())
-			.engagementRate(meeting.calculateEngagementRate(meetingQuestion))
+			.engagementRate(meetingQuestion.calculateEngagementRate())
 			.startTime(meetingQuestion.getEpochMilliStartTime())
 			.isAnswered(isAnswered)
 			.isQuestionRegistered(true)

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/response/MostInactiveMeetingQuestionListResponseDetail.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/response/MostInactiveMeetingQuestionListResponseDetail.java
@@ -5,7 +5,6 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
 import java.util.Optional;
 
 import org.depromeet.sambad.moring.answer.domain.Answer;
-import org.depromeet.sambad.moring.meeting.meeting.domain.Meeting;
 import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -31,13 +30,11 @@ public record MostInactiveMeetingQuestionListResponseDetail(
 
 	public static MostInactiveMeetingQuestionListResponseDetail of(MeetingQuestion meetingQuestion,
 		Optional<Answer> bestAnswer) {
-		Meeting meeting = meetingQuestion.getMeeting();
-
 		return MostInactiveMeetingQuestionListResponseDetail.builder()
 			.meetingQuestionId(meetingQuestion.getId())
 			.title(meetingQuestion.getQuestion().getTitle())
 			.content(bestAnswer.isPresent() ? bestAnswer.get().getContent() : null)
-			.engagementRate(meeting.calculateEngagementRate(meetingQuestion))
+			.engagementRate(meetingQuestion.calculateEngagementRate())
 			.startTime(meetingQuestion.getEpochMilliStartTime())
 			.build();
 	}

--- a/src/main/java/org/depromeet/sambad/moring/question/domain/Question.java
+++ b/src/main/java/org/depromeet/sambad/moring/question/domain/Question.java
@@ -31,9 +31,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Question extends BaseTimeEntity {
 
-	private static final int MIN_ANSWER_COUNT = 2;
-	private static final int MAX_ANSWER_COUNT = 9;
-
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "question_id")

--- a/src/main/java/org/depromeet/sambad/moring/question/domain/QuestionType.java
+++ b/src/main/java/org/depromeet/sambad/moring/question/domain/QuestionType.java
@@ -5,7 +5,7 @@ import org.depromeet.sambad.moring.question.presentation.exception.AnswerCountOu
 public enum QuestionType {
 	SINGLE_CHOICE, MULTIPLE_SHORT_CHOICE, MULTIPLE_DESCRIPTIVE_CHOICE;
 
-	private static final int MIN_ANSWER_COUNT = 2;
+	private static final int MIN_ANSWER_COUNT = 1;
 	private static final int MULTI_CHOICE_MAX_ANSWER_COUNT = 9;
 
 	public static void validateAnswerCount(QuestionType questionType, int answerCount) {

--- a/src/main/java/org/depromeet/sambad/moring/question/presentation/exception/QuestionExceptionCode.java
+++ b/src/main/java/org/depromeet/sambad/moring/question/presentation/exception/QuestionExceptionCode.java
@@ -12,7 +12,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum QuestionExceptionCode implements ExceptionCode {
 
-	ANSWER_COUNT_OUT_OF_RANGE(BAD_REQUEST, "답변 개수가 범위를 벗어났습니다. 2개 이상 16개 이하로 입력해주세요."),
+	ANSWER_COUNT_OUT_OF_RANGE(BAD_REQUEST, "답변 개수가 범위를 벗어났습니다. 1개 이상 16개 이하로 입력해주세요."),
 
 	NOT_FOUND_QUESTION(NOT_FOUND, "릴레이 질문이 존재하지 않습니다."),
 	NOT_FOUND_AVAILABLE_QUESTION(NOT_FOUND, "사용 가능한 질문이 존재하지 않습니다."),


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정


## 📝 개요
- 기획 논의 결정에 따라, 종료된 질문의 경우 종료된 시점의 모임원 수(totalMemberCount)로 참여율을 계산하도록 수정합니다.

## 💡 참고 사항
- 로컬에서 서버 기동 시, 콘솔에 `moring.ShedLock 이 존재하지 않는다` 메시지가 뜨는데요. 해당 오류가 잡혀야, 현재 PR에 대한 테스트를 진행할 수 있을 것 같습니다. (TODO: 머지 전 테스트 필요)
 - MeetingQuestion 테이블에 모임 질문 종료 시점의 모임원 수를 저장하기 위해 `total_member_count` 필드를 추가하였습니다. erdcloud는 최신화해두었고, `dev와 prod 서버 배포 전에 테이블 업데이트 쿼리 실행 작업`이 필요합니다. 🚀 (TODO: 배포 전 쿼리 업데이트 필요)