### PR TITLE
[SAMBAD-266] 같은 선택 모임원 조회 시, 같은 선택 모임원이 없으면 204 반환되도록 수정

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/presentation/MeetingAnswerController.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/presentation/MeetingAnswerController.java
@@ -124,6 +124,8 @@ public class MeetingAnswerController {
 		SelectedAnswerResponse response = meetingAnswerResultService.getSelectedSameAnswer(
 			userId, meetingId, meetingQuestionId);
 
-		return ResponseEntity.ok(response);
+		return response.selectedMembers().isEmpty()
+			? ResponseEntity.noContent().build()
+			: ResponseEntity.ok(response);
 	}
 }


### PR DESCRIPTION

## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- 같은 답변을 선택한 모임원이 없으면, 204 No Content가 반환되도록 수정합니다.
  - 클라이언트에서 모임원이 없을 시에 대한 특별한 대응이 필요합니다.


## 🔗 ISSUE 링크
- resolved [SAMBAD-266](https://www.notion.so/depromeet/204-2a01079bda084641bf1c1b0422f1e20b?pvs=4)