### PR TITLE
[SAMBAD-271] 알림 목록 조회 및 알림 메시지 템플릿 기능 추가

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/common/config/CacheConfig.java
+++ b/src/main/java/org/depromeet/sambad/moring/common/config/CacheConfig.java
@@ -1,0 +1,23 @@
+package org.depromeet.sambad.moring.common.config;
+
+import java.util.List;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+	@Bean
+	public CacheManager cacheManager() {
+		ConcurrentMapCacheManager cacheManager = new ConcurrentMapCacheManager();
+		cacheManager.setAllowNullValues(false);
+		cacheManager.setCacheNames(List.of("eventTemplates"));
+		return cacheManager;
+	}
+
+}

--- a/src/main/java/org/depromeet/sambad/moring/common/logging/ExecutionLoggingAdvice.java
+++ b/src/main/java/org/depromeet/sambad/moring/common/logging/ExecutionLoggingAdvice.java
@@ -29,7 +29,8 @@ public class ExecutionLoggingAdvice {
 		+ "!execution(* org.depromeet.sambad.moring.*.infrastructure.*Properties.*(..)) && "
 		+ "!execution(* org.depromeet.sambad.moring.*.*.infrastructure.*Properties.*(..)) && "
 		+ "!execution(* org.depromeet.sambad.moring.common..*(..)) && "
-		+ "!execution(* org.depromeet.sambad.moring.*.*.annotation..*(..))"
+		+ "!execution(* org.depromeet.sambad.moring.*.*.annotation..*(..)) && "
+		+ "!@annotation(org.depromeet.sambad.moring.common.logging.NoLogging)"
 	)
 	private void logPointcut() {
 	}

--- a/src/main/java/org/depromeet/sambad/moring/common/logging/NoLogging.java
+++ b/src/main/java/org/depromeet/sambad/moring/common/logging/NoLogging.java
@@ -1,0 +1,14 @@
+package org.depromeet.sambad.moring.common.logging;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 메서드에 부착 시, ExecutionLoggingAdvice 내 로깅 대상에서 제외합니다.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NoLogging {
+}

--- a/src/main/java/org/depromeet/sambad/moring/event/application/EventMessageTemplateRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/event/application/EventMessageTemplateRepository.java
@@ -1,0 +1,11 @@
+package org.depromeet.sambad.moring.event.application;
+
+import java.util.Optional;
+
+import org.depromeet.sambad.moring.event.domain.EventMessageTemplate;
+import org.depromeet.sambad.moring.event.domain.EventType;
+
+public interface EventMessageTemplateRepository {
+
+	Optional<EventMessageTemplate> findByType(EventType type);
+}

--- a/src/main/java/org/depromeet/sambad/moring/event/application/EventRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/event/application/EventRepository.java
@@ -1,5 +1,6 @@
 package org.depromeet.sambad.moring.event.application;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,4 +20,7 @@ public interface EventRepository {
 	);
 
 	List<Event> findByMeetingIdAndStatusAndType(Long meetingId, EventStatus eventStatus, EventType eventType);
+
+	List<Event> findByUserIdAndMeetingIdAndCreatedAtAfterOrderByCreatedAtDesc(
+		Long userId, Long meetingId, LocalDateTime keepDays);
 }

--- a/src/main/java/org/depromeet/sambad/moring/event/application/EventService.java
+++ b/src/main/java/org/depromeet/sambad/moring/event/application/EventService.java
@@ -2,10 +2,13 @@ package org.depromeet.sambad.moring.event.application;
 
 import static org.depromeet.sambad.moring.event.domain.EventStatus.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 import org.depromeet.sambad.moring.event.domain.Event;
 import org.depromeet.sambad.moring.event.domain.EventType;
+import org.depromeet.sambad.moring.event.infrastructure.EventProperties;
 import org.depromeet.sambad.moring.event.presentation.excepiton.NotFoundEventException;
 import org.depromeet.sambad.moring.event.presentation.response.PollingEventListResponse;
 import org.depromeet.sambad.moring.meeting.member.domain.MeetingMemberValidator;
@@ -18,35 +21,53 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class EventService {
+
 	private final EventRepository eventRepository;
+	private final EventMessageTemplateRepository eventMessageTemplateRepository;
 	private final MeetingMemberValidator meetingMemberValidator;
 
-	@Transactional
+	private final EventProperties eventProperties;
+
 	public void publish(Long userId, Long meetingId, EventType type) {
+		this.publish(userId, meetingId, type, Map.of(), Map.of());
+	}
+
+	public void publish(
+		Long userId, Long meetingId, EventType type, Map<String, String> contentsMap, Map<String, Object> additionalData
+	) {
 		if (meetingMemberValidator.isNotUserOfMeeting(userId, meetingId)) {
 			log.warn("User is not member of meeting. userId: {}, meetingId: {}", userId, meetingId);
 			return;
 		}
 
-		Event event = Event.publish(userId, meetingId, type);
+		String message = constructEventMessage(type, contentsMap);
+
+		Event event = Event.publish(userId, meetingId, type, message, additionalData);
 		eventRepository.save(event);
 	}
 
-	@Transactional
 	public void inactivate(Long eventId) {
 		Event event = getEventById(eventId);
 		event.inactivate();
 		eventRepository.save(event);
 	}
 
-	@Transactional
+	@Transactional(readOnly = true)
+	public List<Event> getEvents(Long userId, Long meetingId) {
+		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
+		LocalDateTime keepDays = LocalDateTime.now().minusDays(eventProperties.keepDays());
+
+		return eventRepository.findByUserIdAndMeetingIdAndCreatedAtAfterOrderByCreatedAtDesc(
+			userId, meetingId, keepDays);
+	}
+
 	public void inactivateLastEventByType(Long userId, Long meetingId, EventType type) {
 		eventRepository.findFirstByUserIdAndMeetingIdAndStatusAndType(userId, meetingId, ACTIVE, type)
 			.ifPresent(Event::inactivate);
 	}
 
-	@Transactional
 	public PollingEventListResponse getActiveEvents(Long userId, Long meetingId) {
 		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
 		List<Event> events = eventRepository.findByUserIdAndMeetingIdAndStatus(userId, meetingId, ACTIVE);
@@ -59,10 +80,19 @@ public class EventService {
 		return PollingEventListResponse.from(notExpiredEvents);
 	}
 
-	@Transactional
 	public void inactivateLastEventsOfAllMemberByType(Long meetingId, EventType eventType) {
 		List<Event> events = eventRepository.findByMeetingIdAndStatusAndType(meetingId, ACTIVE, eventType);
 		events.forEach(Event::inactivate);
+	}
+
+	private String constructEventMessage(EventType type, Map<String, String> contentsMap) {
+		if (contentsMap.isEmpty()) {
+			return null;
+		}
+
+		return eventMessageTemplateRepository.findByType(type)
+			.map(template -> template.replaceTemplateVariables(contentsMap))
+			.orElse(null);
 	}
 
 	private Event getEventById(Long eventId) {

--- a/src/main/java/org/depromeet/sambad/moring/event/domain/Event.java
+++ b/src/main/java/org/depromeet/sambad/moring/event/domain/Event.java
@@ -7,10 +7,12 @@ import static org.depromeet.sambad.moring.event.domain.EventStatus.*;
 import static org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion.*;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 import org.depromeet.sambad.moring.common.domain.BaseTimeEntity;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
@@ -38,19 +40,32 @@ public class Event extends BaseTimeEntity {
 	@Enumerated(STRING)
 	private EventStatus status;
 
+	private String message;
+
 	private LocalDateTime expiredAt;
 
-	private Event(Long userId, Long meetingId, EventType type, EventStatus status, LocalDateTime expiredAt) {
+	@Column(columnDefinition = "text")
+	@Convert(converter = MapToJsonConverter.class)
+	private Map<String, Object> additionalData = Map.of();
+
+	private Event(
+		Long userId, Long meetingId, EventType type, EventStatus status, String message, LocalDateTime expiredAt,
+		Map<String, Object> additionalData
+	) {
 		this.userId = userId;
 		this.meetingId = meetingId;
 		this.type = type;
 		this.status = status;
+		this.message = message;
 		this.expiredAt = expiredAt;
+		this.additionalData = additionalData;
 	}
 
-	public static Event publish(Long userId, Long meetingId, EventType type) {
+	public static Event publish(
+		Long userId, Long meetingId, EventType type, String message, Map<String, Object> additionalData
+	) {
 		LocalDateTime expiredAt = LocalDateTime.now().plusSeconds(RESPONSE_TIME_LIMIT_SECONDS);
-		return new Event(userId, meetingId, type, ACTIVE, expiredAt);
+		return new Event(userId, meetingId, type, ACTIVE, message, expiredAt, additionalData);
 	}
 
 	public void inactivate() {

--- a/src/main/java/org/depromeet/sambad/moring/event/domain/EventMessageTemplate.java
+++ b/src/main/java/org/depromeet/sambad/moring/event/domain/EventMessageTemplate.java
@@ -1,0 +1,43 @@
+package org.depromeet.sambad.moring.event.domain;
+
+import static jakarta.persistence.EnumType.*;
+import static jakarta.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class EventMessageTemplate {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	@Column(name = "event_template_id")
+	private Long id;
+
+	@Enumerated(STRING)
+	@Column(columnDefinition = "varchar(50)")
+	private EventType type;
+
+	private String template;
+
+	public String replaceTemplateVariables(Map<String, String> contentsMap) {
+		String message = template;
+		for (String key : contentsMap.keySet()) {
+			String regex = Pattern.quote("#{" + key + "}");
+			message = message.replaceAll(regex, Matcher.quoteReplacement(contentsMap.get(key)));
+		}
+		return message;
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moring/event/domain/EventType.java
+++ b/src/main/java/org/depromeet/sambad/moring/event/domain/EventType.java
@@ -1,25 +1,8 @@
 package org.depromeet.sambad.moring.event.domain;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
-import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
-
 public enum EventType {
 	QUESTION_REGISTERED,
 	TARGET_MEMBER,
 	HAND_WAVING_REQUESTED,
 	;
-
-	public static Set<EventType> of(MeetingQuestion meetingQuestion, MeetingMember loginMember) {
-		Set<EventType> eventTypes = new HashSet<>();
-		if (meetingQuestion.getQuestion() != null) {
-			eventTypes.add(EventType.QUESTION_REGISTERED);
-		}
-		if (meetingQuestion.getTargetMember().equals(loginMember)) {
-			eventTypes.add(EventType.TARGET_MEMBER);
-		}
-		return eventTypes;
-	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/event/domain/MapToJsonConverter.java
+++ b/src/main/java/org/depromeet/sambad/moring/event/domain/MapToJsonConverter.java
@@ -1,0 +1,41 @@
+package org.depromeet.sambad.moring.event.domain;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class MapToJsonConverter implements AttributeConverter<Map<String, Object>, String> {
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Override
+	public String convertToDatabaseColumn(Map<String, Object> attribute) {
+		if (attribute == null) {
+			return null;
+		}
+		try {
+			return objectMapper.writeValueAsString(attribute);
+		} catch (JsonProcessingException e) {
+			throw new IllegalArgumentException("Could not convert map to JSON", e);
+		}
+	}
+
+	@Override
+	public Map<String, Object> convertToEntityAttribute(String dbData) {
+		if (dbData == null) {
+			return null;
+		}
+		try {
+			return objectMapper.readValue(dbData, HashMap.class);
+		} catch (IOException e) {
+			throw new IllegalArgumentException("Could not convert JSON to map", e);
+		}
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moring/event/infrastructure/EventJpaRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/event/infrastructure/EventJpaRepository.java
@@ -1,5 +1,6 @@
 package org.depromeet.sambad.moring.event.infrastructure;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,4 +17,7 @@ public interface EventJpaRepository extends JpaRepository<Event, Long> {
 	);
 
 	List<Event> findByMeetingIdAndStatusAndType(Long meetingId, EventStatus eventStatus, EventType eventType);
+
+	List<Event> findByUserIdAndMeetingIdAndCreatedAtAfterOrderByCreatedAtDesc(
+		Long userId, Long meetingId, LocalDateTime keepDays);
 }

--- a/src/main/java/org/depromeet/sambad/moring/event/infrastructure/EventMessageTemplateJpaRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/event/infrastructure/EventMessageTemplateJpaRepository.java
@@ -1,0 +1,12 @@
+package org.depromeet.sambad.moring.event.infrastructure;
+
+import java.util.Optional;
+
+import org.depromeet.sambad.moring.event.domain.EventMessageTemplate;
+import org.depromeet.sambad.moring.event.domain.EventType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventMessageTemplateJpaRepository extends JpaRepository<EventMessageTemplate, Long> {
+
+	Optional<EventMessageTemplate> findByType(EventType type);
+}

--- a/src/main/java/org/depromeet/sambad/moring/event/infrastructure/EventMessageTemplateRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moring/event/infrastructure/EventMessageTemplateRepositoryImpl.java
@@ -1,0 +1,35 @@
+package org.depromeet.sambad.moring.event.infrastructure;
+
+import java.util.Optional;
+
+import org.depromeet.sambad.moring.common.logging.NoLogging;
+import org.depromeet.sambad.moring.event.application.EventMessageTemplateRepository;
+import org.depromeet.sambad.moring.event.domain.EventMessageTemplate;
+import org.depromeet.sambad.moring.event.domain.EventType;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Repository
+public class EventMessageTemplateRepositoryImpl implements EventMessageTemplateRepository {
+
+	private final EventMessageTemplateJpaRepository eventMessageTemplateJpaRepository;
+
+	@Override
+	@Cacheable(value = "eventTemplates", key = "#type", unless = "#result == null")
+	public Optional<EventMessageTemplate> findByType(EventType type) {
+		return eventMessageTemplateJpaRepository.findByType(type);
+	}
+
+	@NoLogging
+	@CacheEvict(value = "eventTemplates", allEntries = true)
+	@Scheduled(fixedRateString = "${caching.spring.event-templates-ttl}")
+	public void evictAllCaches() {
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moring/event/infrastructure/EventProperties.java
+++ b/src/main/java/org/depromeet/sambad/moring/event/infrastructure/EventProperties.java
@@ -1,0 +1,9 @@
+package org.depromeet.sambad.moring.event.infrastructure;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "event")
+public record EventProperties(
+	Long keepDays
+) {
+}

--- a/src/main/java/org/depromeet/sambad/moring/event/infrastructure/EventRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moring/event/infrastructure/EventRepositoryImpl.java
@@ -1,5 +1,6 @@
 package org.depromeet.sambad.moring.event.infrastructure;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -37,6 +38,14 @@ public class EventRepositoryImpl implements EventRepository {
 	@Override
 	public List<Event> findByMeetingIdAndStatusAndType(Long meetingId, EventStatus eventStatus, EventType eventType) {
 		return eventJpaRepository.findByMeetingIdAndStatusAndType(meetingId, eventStatus, eventType);
+	}
+
+	@Override
+	public List<Event> findByUserIdAndMeetingIdAndCreatedAtAfterOrderByCreatedAtDesc(
+		Long userId, Long meetingId, LocalDateTime keepDays
+	) {
+		return eventJpaRepository.findByUserIdAndMeetingIdAndCreatedAtAfterOrderByCreatedAtDesc(
+			userId, meetingId, keepDays);
 	}
 
 	@Override

--- a/src/main/java/org/depromeet/sambad/moring/event/presentation/response/EventListResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/event/presentation/response/EventListResponse.java
@@ -1,0 +1,23 @@
+package org.depromeet.sambad.moring.event.presentation.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
+import java.util.List;
+
+import org.depromeet.sambad.moring.event.domain.Event;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record EventListResponse(
+	@Schema(description = "이벤트 목록", requiredMode = REQUIRED)
+	List<EventResponse> contents
+) {
+
+	public static EventListResponse from(List<Event> events) {
+		List<EventResponse> contents = events.stream()
+			.map(EventResponse::from)
+			.toList();
+
+		return new EventListResponse(contents);
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moring/event/presentation/response/EventResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/event/presentation/response/EventResponse.java
@@ -1,0 +1,49 @@
+package org.depromeet.sambad.moring.event.presentation.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.depromeet.sambad.moring.event.domain.Event;
+import org.depromeet.sambad.moring.event.domain.EventStatus;
+import org.depromeet.sambad.moring.event.domain.EventType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record EventResponse(
+	@Schema(description = "이벤트 ID", example = "1", requiredMode = REQUIRED)
+	Long eventId,
+
+	@Schema(description = "이벤트 타입", example = "QUESTION_REGISTERED", requiredMode = REQUIRED)
+	EventType type,
+
+	@Schema(description = "이벤트 메시지", example = "질문이 등록되었습니다.", requiredMode = NOT_REQUIRED)
+	List<String> messages,
+
+	@Schema(description = "이벤트 상태", example = "ACTIVE", requiredMode = REQUIRED)
+	EventStatus status,
+
+	@Schema(description = "이벤트 타입 별로 필요한 추가 데이터", example = "{\"handWavingId\": 9}", requiredMode = NOT_REQUIRED)
+	Map<String, Object> additionalData,
+
+	@Schema(description = "이벤트 생성 시간 타임 스탬프", example = "1724252079282", requiredMode = REQUIRED)
+	Long createdAt
+) {
+	public static EventResponse from(Event event) {
+		List<String> messages = Optional.ofNullable(event.getMessage())
+			.map(message -> Arrays.asList(message.split("\n")))
+			.orElse(List.of());
+
+		return new EventResponse(
+			event.getId(),
+			event.getType(),
+			messages,
+			event.getStatus(),
+			event.getAdditionalData(),
+			event.getCreatedAtWithEpochMilli()
+		);
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -125,3 +125,10 @@ management:
       enabled: true
     java:
       enabled: true
+
+caching:
+  spring:
+    event-templates-ttl: ${EVENT_TEMPLATES_TTL:1800}
+
+event:
+  keep-days: ${EVENT_KEEP_DAYS:7}


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 📝 개요
- 알림 목록 조회 API를 추가합니다.
  - 비활성화된 알림도 모두 조회합니다.
- 알림의 메시지를 구성하는 기능을 추가합니다.
  - `event_message_template` 테이블을 통해, 이벤트 타입 별 메시지 템플릿을 획득합니다.
  - 해당 테이블의 경우 대부분 변경이 일어나지 않는 데이터로 구성되어 있으므로, Spring Cache 기능을 도입합니다.
- `event.additional_data` 칼럼을 추가합니다.
  - 해당 알림에 대해 추가적인 정보가 필요한 경우에 대응합니다.

## 🔗 ISSUE 링크
- resolved [SAMBAD-271](https://www.notion.so/depromeet/API-3f191c5ca1594eedb3d35c6e772623ae?pvs=4)