### PR TITLE
[SAMBAD-274] 마지막 접속 모임 정보 갱신 로직 구현

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/application/MeetingService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/application/MeetingService.java
@@ -6,12 +6,16 @@ import org.depromeet.sambad.moring.meeting.meeting.domain.Meeting;
 import org.depromeet.sambad.moring.meeting.meeting.domain.MeetingCode;
 import org.depromeet.sambad.moring.meeting.meeting.domain.TypesPerMeeting;
 import org.depromeet.sambad.moring.meeting.meeting.presentation.exception.MeetingNotFoundException;
+import org.depromeet.sambad.moring.meeting.meeting.presentation.exception.NotJoinedAnyMeetingException;
 import org.depromeet.sambad.moring.meeting.meeting.presentation.request.MeetingPersistRequest;
 import org.depromeet.sambad.moring.meeting.meeting.presentation.response.MeetingResponse;
 import org.depromeet.sambad.moring.meeting.meeting.presentation.response.MeetingNameResponse;
 import org.depromeet.sambad.moring.meeting.member.application.MeetingMemberRepository;
 import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
 import org.depromeet.sambad.moring.meeting.member.domain.MeetingMemberValidator;
+import org.depromeet.sambad.moring.user.domain.User;
+import org.depromeet.sambad.moring.user.domain.UserRepository;
+import org.depromeet.sambad.moring.user.presentation.exception.NotFoundUserException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class MeetingService {
 
+	private final UserRepository userRepository;
 	private final MeetingRepository meetingRepository;
 	private final MeetingMemberRepository meetingMemberRepository;
 	private final MeetingTypeRepository meetingTypeRepository;
@@ -35,19 +40,21 @@ public class MeetingService {
 		Meeting meeting = generateMeeting(request);
 		addTypesToMeeting(request, meeting);
 
-		// NOTE: 모임 생성 시점엔 아직 모임장도 모임원 가입이 안된 상태이므로, 오류 발생
-		// 해당 로직 추가한 이유가 궁금합니다.
-		// meetingQuestionService.createActiveQuestion(meeting, meeting.getOwner(), null);
 		return meeting;
 	}
 
 	public MeetingResponse getMeetingResponse(Long userId) {
 		List<MeetingMember> membersOfUser = meetingMemberRepository.findByUserId(userId);
+
+		if (membersOfUser.isEmpty()) {
+			throw new NotJoinedAnyMeetingException();
+		}
+
 		List<Meeting> meetings = membersOfUser.stream()
 			.map(MeetingMember::getMeeting)
 			.toList();
 
-		return MeetingResponse.from(meetings);
+		return MeetingResponse.of(meetings, MeetingMember.getLastMeetingId(membersOfUser));
 	}
 
 	public MeetingNameResponse getMeetingNameByCode(String code) {
@@ -55,6 +62,11 @@ public class MeetingService {
 			.orElseThrow(MeetingNotFoundException::new);
 
 		return MeetingNameResponse.from(meeting);
+	}
+
+	public Meeting getMeeting(Long meetingId) {
+		return meetingRepository.findById(meetingId)
+			.orElseThrow(MeetingNotFoundException::new);
 	}
 
 	private void addTypesToMeeting(MeetingPersistRequest request, Meeting meeting) {

--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/exception/MeetingExceptionCode.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/exception/MeetingExceptionCode.java
@@ -14,6 +14,7 @@ public enum MeetingExceptionCode implements ExceptionCode {
 	EXCEED_MAX_MEETING_COUNT(BAD_REQUEST, "모임 최대 참여 및 개설 횟수를 초과했습니다."),
 
 	MEETING_NOT_FOUND(NOT_FOUND, "모임을 찾을 수 없습니다."),
+	NOT_JOINED_ANY_MEETING(NOT_FOUND, "모임에 전혀 가입되어 있지 않습니다."),
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/exception/NotJoinedAnyMeetingException.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/exception/NotJoinedAnyMeetingException.java
@@ -1,0 +1,11 @@
+package org.depromeet.sambad.moring.meeting.meeting.presentation.exception;
+
+import static org.depromeet.sambad.moring.meeting.meeting.presentation.exception.MeetingExceptionCode.*;
+
+import org.depromeet.sambad.moring.common.exception.BusinessException;
+
+public class NotJoinedAnyMeetingException extends BusinessException {
+	public NotJoinedAnyMeetingException() {
+		super(NOT_JOINED_ANY_MEETING);
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/response/MeetingResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/response/MeetingResponse.java
@@ -10,13 +10,19 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record MeetingResponse(
 	@Schema(description = "가입 되어 있는 모임의 정보 목록", requiredMode = REQUIRED)
-	List<MeetingResponseDetail> meetings
+	List<MeetingResponseDetail> meetings,
+
+	@Schema(description = "마지막으로 접근한 모임 ID", example = "1", requiredMode = REQUIRED)
+	Long lastMeetingId
 ) {
-	public static MeetingResponse from(List<Meeting> meetings) {
+	public static MeetingResponse of(List<Meeting> meetings, Long lastMeetingId) {
 		return new MeetingResponse(
 			meetings.stream()
 				.map(meeting -> new MeetingResponseDetail(meeting.getId(), meeting.getName()))
-				.toList()
+				.toList(),
+			lastMeetingId == null
+				? meetings.get(0).getId()
+				: lastMeetingId
 		);
 	}
 

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMember.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMember.java
@@ -170,4 +170,15 @@ public class MeetingMember extends BaseTimeEntity implements Comparable<MeetingM
 		this.mbti = request.mbti();
 		this.introduction = request.introduction();
 	}
+
+	public Long getUserId() {
+		return user.getId();
+	}
+
+	public static Long getLastMeetingId(List<MeetingMember> meetingMembers) {
+		return meetingMembers.stream()
+			.findFirst()
+			.map(MeetingMember::getUserId)
+			.orElse(null);
+	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/user/application/UserService.java
+++ b/src/main/java/org/depromeet/sambad/moring/user/application/UserService.java
@@ -1,5 +1,6 @@
 package org.depromeet.sambad.moring.user.application;
 
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMemberValidator;
 import org.depromeet.sambad.moring.user.domain.User;
 import org.depromeet.sambad.moring.user.domain.UserRepository;
 import org.depromeet.sambad.moring.user.presentation.exception.NotFoundUserException;
@@ -16,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 public class UserService {
 
 	private final UserRepository userRepository;
+	private final MeetingMemberValidator meetingMemberValidator;
 
 	public UserResponse findByUserId(Long userId) {
 		return userRepository.findById(userId)
@@ -31,5 +33,14 @@ public class UserService {
 		user.completeOnboarding();
 
 		return OnboardingResponse.from(user);
+	}
+
+	@Transactional
+	public void updateLastMeeting(Long userId, Long meetingId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(NotFoundUserException::new);
+
+		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
+		user.updateLastAccessedMeeting(meetingId);
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/user/domain/User.java
+++ b/src/main/java/org/depromeet/sambad/moring/user/domain/User.java
@@ -51,6 +51,8 @@ public class User extends BaseTimeEntity {
 	@Column(columnDefinition = "TINYINT")
 	private Boolean onboardingCompleted;
 
+	private Long lastMeetingId;
+
 	@OneToMany(mappedBy = "user")
 	private List<MeetingMember> meetingMember = new ArrayList<>();
 
@@ -96,5 +98,9 @@ public class User extends BaseTimeEntity {
 
 	public boolean isNotEnteredAnyMeeting() {
 		return meetingMember.isEmpty();
+	}
+
+	public void updateLastAccessedMeeting(Long meetingId) {
+		this.lastMeetingId = meetingId;
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/user/presentation/UserController.java
+++ b/src/main/java/org/depromeet/sambad/moring/user/presentation/UserController.java
@@ -2,17 +2,20 @@ package org.depromeet.sambad.moring.user.presentation;
 
 import org.depromeet.sambad.moring.user.application.UserService;
 import org.depromeet.sambad.moring.user.domain.User;
+import org.depromeet.sambad.moring.user.presentation.request.LastMeetingRequest;
 import org.depromeet.sambad.moring.user.presentation.resolver.UserId;
 import org.depromeet.sambad.moring.user.presentation.response.OnboardingResponse;
 import org.depromeet.sambad.moring.user.presentation.response.UserResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -44,5 +47,16 @@ public class UserController {
 	public ResponseEntity<OnboardingResponse> completeOnboarding(@UserId Long userId) {
 		OnboardingResponse response = userService.completeOnboarding(userId);
 		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "가장 최근 접속 모임 수정", description = "가장 최근 접속한 모임 정보를 수정합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "성공"),
+		@ApiResponse(responseCode = "403", description = "USER_NOT_MEMBER_OF_MEETING")
+	})
+	@PatchMapping("/last-meeting")
+	public ResponseEntity<Void> updateLastMeeting(@UserId Long userId, @RequestBody LastMeetingRequest request) {
+		userService.updateLastMeeting(userId, request.meetingId());
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/user/presentation/request/LastMeetingRequest.java
+++ b/src/main/java/org/depromeet/sambad/moring/user/presentation/request/LastMeetingRequest.java
@@ -1,0 +1,11 @@
+package org.depromeet.sambad.moring.user.presentation.request;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LastMeetingRequest(
+	@Schema(description = "마지막으로 접속한 모임의 ID", example = "1", requiredMode = REQUIRED)
+	Long meetingId
+) {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -131,4 +131,4 @@ caching:
     event-templates-ttl: ${EVENT_TEMPLATES_TTL:1800}
 
 event:
-  keep-days: ${EVENT_KEEP_DAYS:7}
+  keep-days: ${EVENT_KEEP_DAYS:30}


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- `user.last_meeting_id` 칼럼을 추가합니다.
  - null일 경우, 모임 목록의 첫 번째 모임 id를 제공합니다.
- `PATCH /v1/users/last-meeting` API를 추가합니다.
- 기존 `GET /v1/meetings` API에 마지막 접속 모임 필드를 추가합니다.
    
## 🔗 ISSUE 링크
- resolved [SAMBAD-274](https://www.notion.so/depromeet/API-40b590120d0e4e389f713ffaeab6f6fd?pvs=4)