### PR TITLE
[SAMBAD-270] 모임원 목록 조회 API 내 손 흔들어 인사하기 여부 필드 추가

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/presentation/response/SelectedAnswerResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/presentation/response/SelectedAnswerResponse.java
@@ -28,7 +28,9 @@ public record SelectedAnswerResponse(
 				.distinct()
 				.toList(),
 			members.size(),
-			MeetingMemberListResponse.from(members).contents()
+			members.stream()
+				.map(MeetingMemberSummaryResponse::from)
+				.toList()
 		);
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/handwaving/application/HandWavingRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/handwaving/application/HandWavingRepository.java
@@ -1,8 +1,10 @@
 package org.depromeet.sambad.moring.meeting.handwaving.application;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.depromeet.sambad.moring.meeting.handwaving.domain.HandWaving;
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
 
 public interface HandWavingRepository {
 
@@ -11,4 +13,6 @@ public interface HandWavingRepository {
 	Optional<HandWaving> findById(Long handWavingId);
 
 	Optional<HandWaving> findFirstBySenderIdAndReceiverIdOrderByIdDesc(Long senderMemberId, Long receiverMemberId);
+
+	List<MeetingMember> findHandWavedMembersByMeetingMemberId(Long meetingMemberId);
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/handwaving/infrastructure/HandWavingRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/handwaving/infrastructure/HandWavingRepositoryImpl.java
@@ -1,16 +1,26 @@
 package org.depromeet.sambad.moring.meeting.handwaving.infrastructure;
 
+import static org.depromeet.sambad.moring.meeting.handwaving.domain.HandWavingStatus.*;
+import static org.depromeet.sambad.moring.meeting.handwaving.domain.QHandWaving.*;
+import static org.depromeet.sambad.moring.meeting.member.domain.QMeetingMember.*;
+
+import java.util.List;
 import java.util.Optional;
 
 import org.depromeet.sambad.moring.meeting.handwaving.application.HandWavingRepository;
 import org.depromeet.sambad.moring.meeting.handwaving.domain.HandWaving;
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
 import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
 public class HandWavingRepositoryImpl implements HandWavingRepository {
+
+	private final JPAQueryFactory query;
 	private final HandWavingJpaRepository handWavingJpaRepository;
 
 	@Override
@@ -24,7 +34,24 @@ public class HandWavingRepositoryImpl implements HandWavingRepository {
 	}
 
 	@Override
-	public Optional<HandWaving> findFirstBySenderIdAndReceiverIdOrderByIdDesc(Long senderMemberId, Long receiverMemberId) {
+	public Optional<HandWaving> findFirstBySenderIdAndReceiverIdOrderByIdDesc(Long senderMemberId,
+		Long receiverMemberId) {
 		return handWavingJpaRepository.findFirstBySenderIdAndReceiverIdOrderByIdDesc(senderMemberId, receiverMemberId);
+	}
+
+	@Override
+	public List<MeetingMember> findHandWavedMembersByMeetingMemberId(Long meetingMemberId) {
+		return query.select(meetingMember)
+			.from(handWaving)
+			.join(meetingMember)
+			.on(handWaving.receiver.id.eq(meetingMember.id)
+				.or(handWaving.sender.id.eq(meetingMember.id)))
+			.where(
+				handWaving.receiver.id.eq(meetingMemberId)
+					.or(handWaving.sender.id.eq(meetingMemberId)),
+				handWaving.status.eq(ACCEPTED),
+				meetingMember.id.ne(meetingMemberId)
+			)
+			.fetch();
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberService.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.depromeet.sambad.moring.event.application.EventService;
+import org.depromeet.sambad.moring.meeting.handwaving.application.HandWavingRepository;
 import org.depromeet.sambad.moring.meeting.meeting.application.MeetingRepository;
 import org.depromeet.sambad.moring.meeting.meeting.domain.Meeting;
 import org.depromeet.sambad.moring.meeting.meeting.domain.MeetingCode;
@@ -44,6 +45,7 @@ public class MeetingMemberService {
 	private final MeetingQuestionRepository meetingQuestionRepository;
 	private final MeetingMemberHobbyRepository meetingMemberHobbyRepository;
 	private final EventService eventService;
+	private final HandWavingRepository handWavingRepository;
 
 	@Transactional
 	public MeetingMemberPersistResponse registerMeetingMember(
@@ -85,7 +87,12 @@ public class MeetingMemberService {
 	public MeetingMemberListResponse getMeetingMembers(Long userId, Long meetingId) {
 		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
 
-		return MeetingMemberListResponse.from(meetingMemberRepository.findByMeetingIdOrderByName(meetingId));
+		MeetingMember me = getByUserIdAndMeetingId(userId, meetingId);
+		List<MeetingMember> members = meetingMemberRepository.findByMeetingIdOrderByName(meetingId);
+
+		List<MeetingMember> handWavedMembers = handWavingRepository.findHandWavedMembersByMeetingMemberId(me.getId());
+
+		return MeetingMemberListResponse.from(members, handWavedMembers);
 	}
 
 	public MeetingMember getByUserIdAndMeetingId(Long userId, Long meetingId) {

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/response/MeetingMemberListResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/response/MeetingMemberListResponse.java
@@ -14,13 +14,13 @@ public record MeetingMemberListResponse(
 		example = "[{\"meetingMemberId\":1,\"name\":\"이한음\",\"profileImageFileUrl\":\"https://example.com\",\"role\":\"OWNER\"}]",
 		requiredMode = REQUIRED
 	)
-	List<MeetingMemberSummaryResponse> contents
+	List<MeetingMemberListResponseDetail> contents
 ) {
 
-	public static MeetingMemberListResponse from(List<MeetingMember> members) {
-		List<MeetingMemberSummaryResponse> memberResponses = members.stream()
+	public static MeetingMemberListResponse from(List<MeetingMember> members, List<MeetingMember> handWavedMembers) {
+		List<MeetingMemberListResponseDetail> memberResponses = members.stream()
 			.sorted()
-			.map(MeetingMemberSummaryResponse::from)
+			.map(member -> MeetingMemberListResponseDetail.from(member, handWavedMembers))
 			.toList();
 
 		return new MeetingMemberListResponse(memberResponses);

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/response/MeetingMemberListResponseDetail.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/response/MeetingMemberListResponseDetail.java
@@ -1,0 +1,39 @@
+package org.depromeet.sambad.moring.meeting.member.presentation.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
+import java.util.List;
+
+import org.depromeet.sambad.moring.file.presentation.annotation.FullFileUrl;
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
+import org.depromeet.sambad.moring.meeting.member.domain.MeetingMemberRole;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MeetingMemberListResponseDetail(
+	@Schema(description = "모임원 ID", example = "1", requiredMode = REQUIRED)
+	Long meetingMemberId,
+
+	@Schema(description = "모임원 이름", example = "이한음", requiredMode = REQUIRED)
+	String name,
+
+	@FullFileUrl
+	@Schema(description = "모임원 프로필 이미지 URL", example = "https://example.com", requiredMode = REQUIRED)
+	String profileImageFileUrl,
+
+	@Schema(description = "모임원 역할", example = "OWNER", requiredMode = REQUIRED)
+	MeetingMemberRole role,
+
+	@Schema(description = "서로 손 흔들어 인사하기를 수행했는지 여부", example = "true", requiredMode = REQUIRED)
+	boolean isHandWaved
+) {
+	public static MeetingMemberListResponseDetail from(MeetingMember member, List<MeetingMember> handWavedMembers) {
+		return new MeetingMemberListResponseDetail(
+			member.getId(),
+			member.getName(),
+			member.getProfileImageUrl(),
+			member.getRole(),
+			handWavedMembers.contains(member)
+		);
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionService.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.depromeet.sambad.moring.event.application.EventService;
+import org.depromeet.sambad.moring.meeting.handwaving.application.HandWavingRepository;
 import org.depromeet.sambad.moring.meeting.meeting.domain.Meeting;
 import org.depromeet.sambad.moring.meeting.member.application.MeetingMemberService;
 import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
@@ -39,6 +40,7 @@ import lombok.RequiredArgsConstructor;
 public class MeetingQuestionService {
 
 	private final MeetingQuestionRepository meetingQuestionRepository;
+	private final HandWavingRepository handWavingRepository;
 
 	private final MeetingMemberService meetingMemberService;
 	private final QuestionService questionService;
@@ -149,8 +151,11 @@ public class MeetingQuestionService {
 
 		List<MeetingMember> members = meetingQuestionRepository.findMeetingMembersByMeetingQuestionId(
 			meetingQuestion.getId());
+		MeetingMember me = meetingMemberService.getByUserIdAndMeetingId(userId, meetingId);
 
-		return MeetingMemberListResponse.from(members);
+		List<MeetingMember> handWavedMembers = handWavingRepository.findHandWavedMembersByMeetingMemberId(me.getId());
+
+		return MeetingMemberListResponse.from(members, handWavedMembers);
 	}
 
 	private CurrentMeetingQuestionResponse getCurrentMeetingQuestionResponse(


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- `손 흔들어 인사하기` 여부를 확인할 수 있는 필드를 추가합니다.
- `MeetingMemberSummaryResponse`와 `MeetingMemberListReponseDetail`을 분리합니다.
  - `MeetingMemberSummaryResponse`는 범용적으로 사용되며, 사용될 때 마다 손 흔들어 인사하기 여부를 매번 확인하기엔 어려움이 있습니다.

## 🔗 ISSUE 링크
- resolved [SAMBAD-270](https://www.notion.so/depromeet/API-4be4505a35e24950b260558f8c29c18d?pvs=4)