### PR TITLE
[SAMBAD-280] data jpa 메서드 명 충돌로 인해 애플리케이션 구동 실패하는 이슈 수정

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMember.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMember.java
@@ -171,14 +171,11 @@ public class MeetingMember extends BaseTimeEntity implements Comparable<MeetingM
 		this.introduction = request.introduction();
 	}
 
-	public Long getUserId() {
-		return user.getId();
-	}
-
 	public static Long getLastMeetingId(List<MeetingMember> meetingMembers) {
 		return meetingMembers.stream()
 			.findFirst()
-			.map(MeetingMember::getUserId)
+			.map(MeetingMember::getUser)
+			.map(User::getId)
 			.orElse(null);
 	}
 }


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
```java
public Long getUserId() {
    return user.getId();
}
```
- 위 메서드를 `MeetingMember` 엔티티에 추가 시, 하단의 기존 Data jpa 메서드와 충돌이 발생합니다.
```java
List<MeetingMember> findByUserId(Long userId);
```


## 🔗 ISSUE 링크
- resolved [SAMBAD-280](https://www.notion.so/depromeet/MeetingMemberJpaRepository-22ed9483f2f7447a8f683d517064328f?pvs=4)