### PR TITLE
[SAMBAD-283] 모임 구분 없이 next target member 조회되는 이슈 수정

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/response/MeetingMemberSummaryResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/response/MeetingMemberSummaryResponse.java
@@ -23,6 +23,9 @@ public record MeetingMemberSummaryResponse(
 	MeetingMemberRole role
 ) {
 	public static MeetingMemberSummaryResponse from(MeetingMember member) {
+		if (member == null) {
+			return null;
+		}
 		return new MeetingMemberSummaryResponse(
 			member.getId(),
 			member.getName(),

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionRepository.java
@@ -32,7 +32,8 @@ public interface MeetingQuestionRepository {
 
 	Optional<MeetingQuestion> findByMeetingIdAndMeetingQuestionId(Long meetingId, Long meetingQuestionId);
 
-	Optional<MeetingQuestion> findFirstByStatusAndStartTimeAfterOrderByStartTime(MeetingQuestionStatus status, LocalDateTime now);
+	Optional<MeetingQuestion> findFirstByMeetingIdAndStatusAndStartTimeAfterOrderByStartTime(
+		Long meetingId, MeetingQuestionStatus status, LocalDateTime now);
 
 	List<MeetingQuestionStatisticsDetail> findStatistics(Long meetingQuestionId);
 

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/application/MeetingQuestionService.java
@@ -158,7 +158,8 @@ public class MeetingQuestionService {
 		if (activeMeetingQuestion.getQuestion() == null) {
 			return CurrentMeetingQuestionResponse.questionNotRegisteredOf(activeMeetingQuestion);
 		} else {
-			MeetingMember nextTargetMember = meetingQuestionRepository.findFirstByStatusAndStartTimeAfterOrderByStartTime(
+			MeetingMember nextTargetMember = meetingQuestionRepository.findFirstByMeetingIdAndStatusAndStartTimeAfterOrderByStartTime(
+					activeMeetingQuestion.getMeeting().getId(),
 					NOT_STARTED,
 					LocalDateTime.now())
 				.map(MeetingQuestion::getTargetMember)

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionJpaRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionJpaRepository.java
@@ -19,7 +19,8 @@ public interface MeetingQuestionJpaRepository extends JpaRepository<MeetingQuest
 	Optional<MeetingQuestion> findFirstByMeetingIdAndStatusOrderByStartTime(Long meetingId,
 		MeetingQuestionStatus status);
 
-	Optional<MeetingQuestion> findFirstByStatusAndStartTimeAfterOrderByStartTime(MeetingQuestionStatus status, LocalDateTime now);
+	Optional<MeetingQuestion> findFirstByMeetingIdAndStatusAndStartTimeAfterOrderByStartTime(
+		Long meetingId, MeetingQuestionStatus status, LocalDateTime now);
 
 	Optional<MeetingQuestion> findFirstByMeetingIdAndStatusAndQuestionIsNotNullOrderByStartTime(Long meetingId,
 		MeetingQuestionStatus status);

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/infrastructure/MeetingQuestionRepositoryImpl.java
@@ -67,9 +67,10 @@ public class MeetingQuestionRepositoryImpl implements MeetingQuestionRepository 
 	}
 
 	@Override
-	public Optional<MeetingQuestion> findFirstByStatusAndStartTimeAfterOrderByStartTime(MeetingQuestionStatus status,
-		LocalDateTime now) {
-		return meetingQuestionJpaRepository.findFirstByStatusAndStartTimeAfterOrderByStartTime(status, now);
+	public Optional<MeetingQuestion> findFirstByMeetingIdAndStatusAndStartTimeAfterOrderByStartTime(
+		Long meetingId, MeetingQuestionStatus status, LocalDateTime now) {
+		return meetingQuestionJpaRepository.findFirstByMeetingIdAndStatusAndStartTimeAfterOrderByStartTime(
+			meetingId, status, now);
 	}
 
 	@Override


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- 멀티모듈 분리하다 발견했습니다 😅

## 🔗 ISSUE 링크
- resolved [SAMBAD-283](https://www.notion.so/depromeet/next-target-member-3a9c180b47e044b788c6688820926b93?pvs=4)