### PR TITLE
[SAMBAD-274] 마지막 접속 모임 필드가 userId로 잘못 반환되는 이슈 수정

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMember.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMember.java
@@ -175,7 +175,7 @@ public class MeetingMember extends BaseTimeEntity implements Comparable<MeetingM
 		return meetingMembers.stream()
 			.findFirst()
 			.map(MeetingMember::getUser)
-			.map(User::getId)
+			.map(User::getLastMeetingId)
 			.orElse(null);
 	}
 }


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- 제곧내입니다.

## 🔗 ISSUE 링크
- resolved [SAMBAD-274](https://www.notion.so/depromeet/API-40b590120d0e4e389f713ffaeab6f6fd?pvs=4)