### PR TITLE
[SAMBAD-288] 모임원 목록 조회 시 자신은 제외하도록 수정

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberRepository.java
@@ -14,7 +14,7 @@ public interface MeetingMemberRepository {
 
 	Optional<MeetingMember> findByUserIdAndMeetingId(Long userId, Long meetingId);
 
-	List<MeetingMember> findByMeetingIdOrderByName(Long meetingId);
+	List<MeetingMember> findByMeetingIdAndMeetingMemberIdNotOrderByName(Long meetingId, Long loginMeetingMemberId);
 
 	List<MeetingMember> findNextTargetsByMeeting(Long meetingId, Long loginMeetingMemberId,
 		List<Long> excludeMemberIds);

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberService.java
@@ -64,7 +64,9 @@ public class MeetingMemberService {
 	}
 
 	public MeetingMemberListResponse getMeetingMembers(Long userId, Long meetingId) {
+		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
 		MeetingMember member = getByUserIdAndMeetingId(userId, meetingId);
+
 		return MeetingMemberListResponse.from(
 			meetingMemberRepository.findByMeetingIdAndMeetingMemberIdNotOrderByName(meetingId, member.getId()));
 	}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberService.java
@@ -64,9 +64,9 @@ public class MeetingMemberService {
 	}
 
 	public MeetingMemberListResponse getMeetingMembers(Long userId, Long meetingId) {
-		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
-
-		return MeetingMemberListResponse.from(meetingMemberRepository.findByMeetingIdOrderByName(meetingId));
+		MeetingMember member = getByUserIdAndMeetingId(userId, meetingId);
+		return MeetingMemberListResponse.from(
+			meetingMemberRepository.findByMeetingIdAndMeetingMemberIdNotOrderByName(meetingId, member.getId()));
 	}
 
 	public MeetingMember getByUserIdAndMeetingId(Long userId, Long meetingId) {

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/infrastructure/MeetingMemberJpaRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/infrastructure/MeetingMemberJpaRepository.java
@@ -10,7 +10,7 @@ public interface MeetingMemberJpaRepository extends JpaRepository<MeetingMember,
 
 	List<MeetingMember> findByUserId(Long userId);
 
-	List<MeetingMember> findByMeetingIdOrderByName(Long meetingId);
+	List<MeetingMember> findByMeetingIdAndIdNotOrderByName(Long meetingId, Long meetingMemberId);
 
 	Optional<MeetingMember> findByUserIdAndMeetingId(Long userId, Long meetingId);
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/infrastructure/MeetingMemberRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/infrastructure/MeetingMemberRepositoryImpl.java
@@ -58,9 +58,10 @@ public class MeetingMemberRepositoryImpl implements MeetingMemberRepository {
 		return meetingMemberQueryRepository.isOwnerExceedingMaxMeetings(meetingId, maxHostMeetings);
 	}
 
-	@Override
-	public List<MeetingMember> findByMeetingIdOrderByName(Long meetingId) {
-		return meetingMemberJpaRepository.findByMeetingIdOrderByName(meetingId);
+	public List<MeetingMember> findByMeetingIdAndMeetingMemberIdNotOrderByName(Long meetingId,
+		Long loginMeetingMemberId) {
+		return meetingMemberJpaRepository.findByMeetingIdAndIdNotOrderByName(meetingId,
+			loginMeetingMemberId);
 	}
 
 	@Override

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/MeetingMemberController.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/MeetingMemberController.java
@@ -67,7 +67,8 @@ public class MeetingMemberController {
 		return ResponseEntity.ok(response);
 	}
 
-	@Operation(summary = "모임원 목록 조회", description = "특정 모임의 모임원 목록을 조회합니다.")
+	@Operation(summary = "모임원 목록 조회", description = "- 특정 모임의 모임원 목록을 조회합니다.\n"
+		+ "- 자기 자신은 목록에서 제외합니다.")
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "모임원 목록 조회 성공"),
 		@ApiResponse(responseCode = "403", description = "USER_NOT_MEMBER_OF_MEETING")


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정


## 📝 개요
- 모임원 목록 조회 API 의 요청 시, 자신을 제외한 목록을 응답하도록 수정합니다.

## 참고 사항
```
2024-08-24T02:40:10.192+09:00  INFO 12996 --- [moring-api] [nio-8080-exec-6] p6spy                                    : [SQL] statement | 1 ms | connectionId = 59 
    select
        mm1_0.meeting_member_id,
        mm1_0.birth,
        mm1_0.created_at,
        mm1_0.gender,
        mm1_0.introduction,
        mm1_0.job,
        mm1_0.location,
        mm1_0.mbti,
        mm1_0.meeting_id,
        mm1_0.name,
        mm1_0.profile_image_file_id,
        mm1_0.role,
        mm1_0.updated_at,
        mm1_0.user_id      
    from
        meeting_member mm1_0      
    where
        mm1_0.meeting_id=1          
        and mm1_0.meeting_member_id<>21      
    order by
        mm1_0.name
2024-08-24T02:40:10.200+09:00  INFO 12996 --- [moring-api] [nio-8080-exec-6] o.d.s.m.c.l.ExecutionLoggingAdvice       : [SUCCESS] MeetingMemberJpaRepository | findByMeetingIdAndIdNotOrderByName | return = [org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@108785ff, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@58c14cb3, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@4e09c6cf, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@72307777, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@4e546eed, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@71ebaced, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@10fb1663, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@15588a7a, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@b05e524, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@462ccf8e, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@4dfb0a49, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@51890fd5, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@12e2635b, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@4014f68c, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@60cda4ae, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@157dee7, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@72bc534b, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@7e7a02c7, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@12ae8898, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@1dca67d2]
2024-08-24T02:40:10.200+09:00  INFO 12996 --- [moring-api] [nio-8080-exec-6] o.d.s.m.c.l.ExecutionLoggingAdvice       : [SUCCESS] MeetingMemberRepositoryImpl | findByMeetingIdAndMeetingMemberIdNotOrderByName | return = [org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@108785ff, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@58c14cb3, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@4e09c6cf, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@72307777, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@4e546eed, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@71ebaced, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@10fb1663, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@15588a7a, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@b05e524, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@462ccf8e, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@4dfb0a49, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@51890fd5, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@12e2635b, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@4014f68c, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@60cda4ae, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@157dee7, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@72bc534b, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@7e7a02c7, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@12ae8898, org.depromeet.sambad.moring.meeting.member.domain.MeetingMember@1dca67d2]
2024-08-24T02:40:10.202+09:00  INFO 12996 --- [moring-api] [nio-8080-exec-6] p6spy                                    : [SQL] statement | 0 ms | connectionId = 59 
    select
        fe1_0.file_id,
        fe1_0.created_at,
        fe1_0.is_default,
        fe1_0.logical_name,
        fe1_0.physical_path,
        fe1_0.updated_at      
    from
        file fe1_0      
    where
        fe1_0.file_id=1
2024-08-24T02:40:10.204+09:00  INFO 12996 --- [moring-api] [nio-8080-exec-6] p6spy                                    : [SQL] statement | 0 ms | connectionId = 59 
    select
        fe1_0.file_id,
        fe1_0.created_at,
        fe1_0.is_default,
        fe1_0.logical_name,
        fe1_0.physical_path,
        fe1_0.updated_at      
    from
        file fe1_0      
    where
        fe1_0.file_id=16
2024-08-24T02:40:10.206+09:00  INFO 12996 --- [moring-api] [nio-8080-exec-6] p6spy                                    : [SQL] statement | 0 ms | connectionId = 59 
    select
        fe1_0.file_id,
        fe1_0.created_at,
        fe1_0.is_default,
        fe1_0.logical_name,
        fe1_0.physical_path,
        fe1_0.updated_at      
    from
        file fe1_0      
    where
        fe1_0.file_id=2
2024-08-24T02:40:10.207+09:00  INFO 12996 --- [moring-api] [nio-8080-exec-6] p6spy                                    : [SQL] statement | 0 ms | connectionId = 59 
    select
        fe1_0.file_id,
        fe1_0.created_at,
        fe1_0.is_default,
        fe1_0.logical_name,
        fe1_0.physical_path,
        fe1_0.updated_at      
    from
        file fe1_0      
    where
        fe1_0.file_id=3
2024-08-24T02:40:10.208+09:00  INFO 12996 --- [moring-api] [nio-8080-exec-6] p6spy                                    : [SQL] statement | 0 ms | connectionId = 59 
    select
        fe1_0.file_id,
        fe1_0.created_at,
        fe1_0.is_default,
        fe1_0.logical_name,
        fe1_0.physical_path,
        fe1_0.updated_at      
    from
        file fe1_0      
    where
        fe1_0.file_id=17
```

file 관련 N+1 문제가 발생하고 있어용 추후에 쿼리 개선이 필요할 듯 합니다~