### PR TITLE
[SAMBAD-294] 타겟 선정에 대한 예외 구별을 통해 명확한 예외 전달하도록 수정

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMember.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMember.java
@@ -14,7 +14,7 @@ import org.depromeet.sambad.moring.file.domain.FileEntity;
 import org.depromeet.sambad.moring.meeting.meeting.domain.Meeting;
 import org.depromeet.sambad.moring.meeting.member.presentation.request.MeetingMemberPersistRequest;
 import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
-import org.depromeet.sambad.moring.meeting.question.presentation.exception.InvalidMeetingMemberTargetException;
+import org.depromeet.sambad.moring.meeting.question.presentation.exception.InvalidMeetingMemberNextTargetException;
 import org.depromeet.sambad.moring.user.domain.User;
 
 import jakarta.persistence.Column;
@@ -153,7 +153,7 @@ public class MeetingMember extends BaseTimeEntity implements Comparable<MeetingM
 
 	public void validateNextTarget(MeetingMember targetMember) {
 		if (isOtherMeeting(targetMember) || Objects.equals(this.user, targetMember.getUser())) {
-			throw new InvalidMeetingMemberTargetException();
+			throw new InvalidMeetingMemberNextTargetException();
 		}
 	}
 

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/MeetingQuestionController.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/MeetingQuestionController.java
@@ -46,7 +46,7 @@ public class MeetingQuestionController {
 		@ApiResponse(responseCode = "201"),
 		@ApiResponse(responseCode = "404", description = "NOT_FOUND_QUESTION"),
 		@ApiResponse(responseCode = "409", description = "DUPLICATE_MEETING_QUESTION / DUPLICATE_QUESTION / "
-			+ "INVALID_MEETING_MEMBER_TARGET")
+			+ "INVALID_MEETING_MEMBER_NEXT_TARGET")
 	})
 	@PostMapping
 	public ResponseEntity<CurrentMeetingQuestionResponse> save(

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/exception/InvalidMeetingMemberNextTargetException.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/exception/InvalidMeetingMemberNextTargetException.java
@@ -1,0 +1,12 @@
+package org.depromeet.sambad.moring.meeting.question.presentation.exception;
+
+import static org.depromeet.sambad.moring.meeting.question.presentation.exception.MeetingQuestionExceptionCode.*;
+
+import org.depromeet.sambad.moring.common.exception.BusinessException;
+
+public class InvalidMeetingMemberNextTargetException extends BusinessException {
+
+	public InvalidMeetingMemberNextTargetException() {
+		super(INVALID_MEETING_MEMBER_NEXT_TARGET);
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/exception/MeetingQuestionExceptionCode.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/exception/MeetingQuestionExceptionCode.java
@@ -12,7 +12,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MeetingQuestionExceptionCode implements ExceptionCode {
 
-	INVALID_MEETING_MEMBER_TARGET(BAD_REQUEST, "본인 혹은 다른 모임의 모임원은 대상이 될 수 없습니다."),
+	INVALID_MEETING_MEMBER_TARGET(BAD_REQUEST, "현재 질문인이 아닌 유저는 질문을 등록할 수 없습니다."),
+	INVALID_MEETING_MEMBER_NEXT_TARGET(BAD_REQUEST, "본인 혹은 다른 모임의 모임원은 대상이 될 수 없습니다."),
 
 	NOT_FOUND_MEETING_QUESTION(NOT_FOUND, "모임의 릴레이 질문이 존재하지 않습니다."),
 


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- 다음 타겟 선정 혹은 현재 타겟에 대한 검증은 예외 구별이 필요합니다.