### PR TITLE
[SAMBAD-291] 종료된 질문 목록 조회 시 페이지 개수 응답 오류 수정

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/response/FullInactiveMeetingQuestionListResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/question/presentation/response/FullInactiveMeetingQuestionListResponse.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 import org.depromeet.sambad.moring.common.response.PageableResponse;
 import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
-import org.springframework.data.domain.Pageable;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -22,11 +21,10 @@ public record FullInactiveMeetingQuestionListResponse<T>(
 ) {
 
 	public static FullInactiveMeetingQuestionListResponse of(List<MeetingQuestion> meetingQuestions,
-		Pageable pageable) {
+		PageableResponse pageableResponse) {
 		List<FullInactiveMeetingQuestionListResponseDetail> responseDetails = FullInactiveMeetingQuestionListResponseDetail.from(
 			meetingQuestions);
 
-		return new FullInactiveMeetingQuestionListResponse(responseDetails,
-			PageableResponse.of(pageable, responseDetails));
+		return new FullInactiveMeetingQuestionListResponse(responseDetails, pageableResponse);
 	}
 }


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- 페이징 응답 시 전체 데이터 개수를 사용하여 페이지 개수를 얻기 위함이기 때문에, 페이징 처리된 리스트가 아닌 totalElement 리스트가 필요합니다. 이에 대한 수정 작업을 반영합니다.