### PR TITLE
[SAMBAD-290] 릴레이 질문 목록 조회 시 종료 상태만 조회하도록 수정

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerQueryRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerQueryRepository.java
@@ -103,6 +103,7 @@ public class MeetingAnswerQueryRepository {
 			.join(meetingAnswer).on(meetingQuestion.eq(meetingAnswer.meetingQuestion)).fetchJoin()
 			.join(meetingMember).on(meetingMember.eq(meetingAnswer.meetingMember)).fetchJoin()
 			.where(meetingMember.id.eq(meetingMemberId),
+				inactiveCond(),
 				meetingAnswer.isHidden.isFalse())
 			.orderBy(meetingQuestion.createdAt.asc())
 			.fetch();

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerQueryRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerQueryRepository.java
@@ -119,7 +119,6 @@ public class MeetingAnswerQueryRepository {
 
 	public MyMeetingAnswerListResponse findAllByMyMeetingMemberId(Long meetingMemberId) {
 
-		//fixme
 		List<MeetingQuestion> meetingQuestions = queryFactory.select(meetingQuestion)
 			.from(meetingQuestion)
 			.join(meetingAnswer).on(meetingQuestion.eq(meetingAnswer.meetingQuestion)).fetchJoin()

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerQueryRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerQueryRepository.java
@@ -4,8 +4,10 @@ import static com.querydsl.core.types.dsl.Expressions.*;
 import static org.depromeet.sambad.moring.meeting.answer.domain.QMeetingAnswer.*;
 import static org.depromeet.sambad.moring.meeting.comment.domain.comment.QMeetingQuestionComment.*;
 import static org.depromeet.sambad.moring.meeting.member.domain.QMeetingMember.*;
+import static org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestionStatus.*;
 import static org.depromeet.sambad.moring.meeting.question.domain.QMeetingQuestion.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 
@@ -20,6 +22,7 @@ import org.depromeet.sambad.moring.meeting.question.domain.MeetingQuestion;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -116,11 +119,13 @@ public class MeetingAnswerQueryRepository {
 
 	public MyMeetingAnswerListResponse findAllByMyMeetingMemberId(Long meetingMemberId) {
 
+		//fixme
 		List<MeetingQuestion> meetingQuestions = queryFactory.select(meetingQuestion)
 			.from(meetingQuestion)
 			.join(meetingAnswer).on(meetingQuestion.eq(meetingAnswer.meetingQuestion)).fetchJoin()
 			.join(meetingMember).on(meetingMember.eq(meetingAnswer.meetingMember)).fetchJoin()
-			.where(meetingMember.id.eq(meetingMemberId))
+			.where(meetingMember.id.eq(meetingMemberId),
+				inactiveCond())
 			.orderBy(meetingQuestion.createdAt.asc())
 			.fetch();
 
@@ -158,5 +163,10 @@ public class MeetingAnswerQueryRepository {
 				meetingAnswer.meetingMember.id.eq(loginMemberId))
 			.fetchFirst();
 		return answerOfList.getIsHidden();
+	}
+
+	private BooleanExpression inactiveCond() {
+		return meetingQuestion.expiredAt.lt(LocalDateTime.now())
+			.or(meetingQuestion.status.eq(INACTIVE));
 	}
 }


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정


## 📝 개요
- 구체화된 기획을 반영합니다.
- 자기소개 페이지 내 릴레이 질문 목록 조회 시 종료 상태 조건을 추가합니다.