### PR TITLE
[SAMBAD-297] 모임 질문 리스트 활성화 시 in 절 NULL 포함 쿼리 오류 수정

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/application/MeetingAnswerRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/application/MeetingAnswerRepository.java
@@ -25,9 +25,9 @@ public interface MeetingAnswerRepository {
 
 	MyMeetingAnswerListResponse findAllByMyMeetingMemberId(Long loginMemberId);
 
-	List<MeetingAnswer> findAllByMeetingMemberIdAndMeetingQuestionIdNotIn(Long meetingMemberId,
-		List<Long> activeMeetingQuestionIds);
+	void updateAllHiddenByMeetingMemberId(Long meetingMemberId);
 
-	List<MeetingAnswer> findAllByMeetingMemberIdAndMeetingQuestionIdIn(Long meetingMemberId,
-		List<Long> activeMeetingQuestionIds);
+	void updateManyHiddenByMeetingMemberIdAndMeetingQuestionId(Long meetingMemberId, List<Long> meetingQuestionIds);
+
+	void updateManyActivateByMeetingMemberIdAndMeetingQuestionId(Long meetingMemberId, List<Long> meetingQuestionIds);
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/application/MeetingAnswerService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/application/MeetingAnswerService.java
@@ -102,12 +102,18 @@ public class MeetingAnswerService {
 	public void updateHidden(Long userId, Long meetingId, List<Long> activeMeetingQuestionIds) {
 		MeetingMember member = meetingMemberService.getByUserIdAndMeetingId(userId, meetingId);
 
-		List<MeetingAnswer> hiddenAnswers = meetingAnswerRepository.findAllByMeetingMemberIdAndMeetingQuestionIdNotIn(
-			member.getId(), activeMeetingQuestionIds);
-		List<MeetingAnswer> activeAnswers = meetingAnswerRepository.findAllByMeetingMemberIdAndMeetingQuestionIdIn(
-			member.getId(), activeMeetingQuestionIds);
+		if (isAllHidden(activeMeetingQuestionIds)) {
+			meetingAnswerRepository.updateAllHiddenByMeetingMemberId(member.getId());
+			return;
+		}
 
-		hiddenAnswers.forEach(MeetingAnswer::updateStatusHidden);
-		activeAnswers.forEach(MeetingAnswer::updateStatusActive);
+		meetingAnswerRepository.updateManyHiddenByMeetingMemberIdAndMeetingQuestionId(member.getId(),
+			activeMeetingQuestionIds);
+		meetingAnswerRepository.updateManyActivateByMeetingMemberIdAndMeetingQuestionId(member.getId(),
+			activeMeetingQuestionIds);
+	}
+
+	private boolean isAllHidden(List<Long> activeMeetingQuestionIds) {
+		return activeMeetingQuestionIds == null || activeMeetingQuestionIds.isEmpty();
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerJpaRepository.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerJpaRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 import org.depromeet.sambad.moring.meeting.answer.domain.MeetingAnswer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MeetingAnswerJpaRepository extends JpaRepository<MeetingAnswer, Long> {
 
@@ -11,9 +13,21 @@ public interface MeetingAnswerJpaRepository extends JpaRepository<MeetingAnswer,
 
 	List<MeetingAnswer> findByMeetingQuestionIdAndMeetingMemberId(Long meetingQuestionId, Long meetingMemberId);
 
-	List<MeetingAnswer> findAllByMeetingMemberIdAndMeetingQuestionIdNotIn(Long meetingMemberId,
+	@Modifying
+	@Query("update MeetingAnswer a set a.isHidden = true where a.meetingMember.id = :meetingMemberId")
+	void updateAllHiddenByMeetingMemberId(Long meetingMemberId);
+
+	@Modifying
+	@Query("update MeetingAnswer a "
+		+ "set a.isHidden = true "
+		+ "where a.meetingMember.id = :meetingMemberId and a.meetingQuestion.id not in (:activeMeetingQuestionIds)")
+	void updateManyHiddenByMeetingMemberIdAndMeetingQuestionId(Long meetingMemberId,
 		List<Long> activeMeetingQuestionIds);
 
-	List<MeetingAnswer> findAllByMeetingMemberIdAndMeetingQuestionIdIn(Long meetingMemberId,
+	@Modifying
+	@Query("update MeetingAnswer a "
+		+ "set a.isHidden = false "
+		+ "where a.meetingMember.id = :meetingMemberId and a.meetingQuestion.id in :activeMeetingQuestionIds")
+	void updateManyActivateByMeetingMemberIdAndMeetingQuestionId(Long meetingMemberId,
 		List<Long> activeMeetingQuestionIds);
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerRepositoryImpl.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/infrastructure/MeetingAnswerRepositoryImpl.java
@@ -60,16 +60,21 @@ public class MeetingAnswerRepositoryImpl implements MeetingAnswerRepository {
 	}
 
 	@Override
-	public List<MeetingAnswer> findAllByMeetingMemberIdAndMeetingQuestionIdIn(Long meetingMemberId,
-		List<Long> activeMeetingQuestionIds) {
-		return meetingAnswerJpaRepository.findAllByMeetingMemberIdAndMeetingQuestionIdIn(meetingMemberId,
-			activeMeetingQuestionIds);
+	public void updateAllHiddenByMeetingMemberId(Long meetingMemberId) {
+		meetingAnswerJpaRepository.updateAllHiddenByMeetingMemberId(meetingMemberId);
 	}
 
 	@Override
-	public List<MeetingAnswer> findAllByMeetingMemberIdAndMeetingQuestionIdNotIn(Long meetingMemberId,
-		List<Long> activeMeetingQuestionIds) {
-		return meetingAnswerJpaRepository.findAllByMeetingMemberIdAndMeetingQuestionIdNotIn(meetingMemberId,
-			activeMeetingQuestionIds);
+	public void updateManyHiddenByMeetingMemberIdAndMeetingQuestionId(Long meetingMemberId,
+		List<Long> meetingQuestionIds) {
+		meetingAnswerJpaRepository.updateManyHiddenByMeetingMemberIdAndMeetingQuestionId(meetingMemberId,
+			meetingQuestionIds);
+	}
+
+	@Override
+	public void updateManyActivateByMeetingMemberIdAndMeetingQuestionId(Long meetingMemberId,
+		List<Long> meetingQuestionIds) {
+		meetingAnswerJpaRepository.updateManyActivateByMeetingMemberIdAndMeetingQuestionId(meetingMemberId,
+			meetingQuestionIds);
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/answer/presentation/MeetingAnswerController.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/answer/presentation/MeetingAnswerController.java
@@ -148,8 +148,8 @@ public class MeetingAnswerController {
 		@UserId Long userId,
 		@Parameter(description = "모임 ID", example = "1", required = true)
 		@Positive @PathVariable Long meetingId,
-		@Parameter(description = "활성화 모임 질문 ID 리스트", example = "1,2,3")
-		@RequestParam(value = "activeMeetingQuestionIds", required = false)
+		@Parameter(description = "활성화 모임 질문 ID 리스트")
+		@RequestParam(value = "activeMeetingQuestionIds", required = false, defaultValue = "")
 		List<Long> activeMeetingQuestionIds
 	) {
 		meetingAnswerService.updateHidden(userId, meetingId, activeMeetingQuestionIds);


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요 
- mysql 쿼리의 IN 절 혹은 NOT IN 절 쿼리에 NULL 이 포함되면, 결과를 반환하지 않는 문제가 있었습니다. [참고 문서](https://dev.mysql.com/blog-archive/a-must-know-about-not-in-in-sql-more-antijoin-optimization/)

  ```sql
        where
                ma1_0.meeting_member_id=21          
                and ma1_0.meeting_question_id not in (NULL);
  ```
- 따라서 활성화 질문 목록이 빈 배열 [] 로 들어오면, 분기처리하여 update하는 방향으로 수정했습니다. [참고 문서](https://dingdingmin-back-end-developer.tistory.com/entry/Spring-data-Jpa-4-Update%EC%99%80-Query)

