### PR TITLE
[SAMBAD-304] `MeetingMemberResponse.hobbyDetails` 필드 추가

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMember.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/domain/MeetingMember.java
@@ -123,7 +123,13 @@ public class MeetingMember extends BaseTimeEntity implements Comparable<MeetingM
 			.orElse(null);
 	}
 
-	public List<String> getHobbies() {
+	public List<Hobby> getHobbies() {
+		return meetingMemberHobbies.stream()
+			.map(MeetingMemberHobby::getHobby)
+			.toList();
+	}
+
+	public List<String> getHobbiesAsString() {
 		return meetingMemberHobbies.stream()
 			.map(MeetingMemberHobby::getHobbyContent)
 			.toList();

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/response/HobbyDetailResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/response/HobbyDetailResponse.java
@@ -1,0 +1,19 @@
+package org.depromeet.sambad.moring.meeting.member.presentation.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
+import org.depromeet.sambad.moring.meeting.member.domain.Hobby;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record HobbyDetailResponse(
+	@Schema(example = "1", description = "모임원 취미 ID", requiredMode = REQUIRED)
+	Long hobbyId,
+
+	@Schema(example = "💩 똥", description = "모임원 취미 내용", requiredMode = REQUIRED)
+	String content
+) {
+	public static HobbyDetailResponse from(Hobby hobby) {
+		return new HobbyDetailResponse(hobby.getId(), hobby.getContent());
+	}
+}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/response/HobbyResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/response/HobbyResponse.java
@@ -14,22 +14,13 @@ public record HobbyResponse(
 		description = "모임원 취미 목록",
 		requiredMode = REQUIRED
 	)
-	List<HobbyDetail> contents
+	List<HobbyDetailResponse> contents
 ) {
-
-	record HobbyDetail(
-		@Schema(example = "1", description = "모임원 취미 ID", requiredMode = REQUIRED)
-		Long hobbyId,
-
-		@Schema(example = "💩 똥", description = "모임원 취미 내용", requiredMode = REQUIRED)
-		String content
-	) {
-	}
 
 	public static HobbyResponse from(List<Hobby> hobbies) {
 		return new HobbyResponse(
 			hobbies.stream()
-				.map(meetingType -> new HobbyDetail(meetingType.getId(), meetingType.getContent()))
+				.map(HobbyDetailResponse::from)
 				.toList()
 		);
 	}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/response/MeetingMemberResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/presentation/response/MeetingMemberResponse.java
@@ -42,6 +42,9 @@ public record MeetingMemberResponse(
 	@Schema(description = "모임원 취미", example = "[\"독서\", \"등산\"]", requiredMode = NOT_REQUIRED)
 	List<String> hobbies,
 
+	@Schema(description = "모임원 취미 상세 정보", requiredMode = NOT_REQUIRED)
+	List<HobbyDetailResponse> hobbyDetails,
+
 	@Schema(description = "모임원 MBTI", example = "ISFP", requiredMode = NOT_REQUIRED)
 	MBTI mbti,
 
@@ -49,6 +52,10 @@ public record MeetingMemberResponse(
 	String introduction
 ) {
 	public static MeetingMemberResponse from(MeetingMember member) {
+		List<HobbyDetailResponse> hobbyDetailResponses = member.getHobbies().stream()
+			.map(HobbyDetailResponse::from)
+			.toList();
+
 		return new MeetingMemberResponse(
 			member.getId(),
 			member.getName(),
@@ -58,7 +65,8 @@ public record MeetingMemberResponse(
 			member.getBirth(),
 			member.getJob(),
 			member.getLocation(),
-			member.getHobbies(),
+			member.getHobbiesAsString(),
+			hobbyDetailResponses,
 			member.getMbti(),
 			member.getIntroduction()
 		);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -111,7 +111,7 @@ cloud:
 
 meeting:
   member:
-    meeting-max-count: ${MEETING_MAX_COUNT:1}
+    meeting-max-count: ${MEETING_MAX_COUNT:10}
     meeting-member-max-count: ${MEETING_MEMBER_MAX_COUNT:50}
     host-max-count: ${HOST_MAX_COUNT:1}
 


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- 모임원의 취미 정보를 자세히 확인할 수 있는 `MeetingMemberResponse.hobbyDetails` 필드를 추가합니다.
  - 하위 호환성 유지를 위해, 기존 `hobbies`는 유지합니다.

## 🔗 ISSUE 링크
- resolved [SAMBAD-304](https://www.notion.so/depromeet/ID-fbd5713bea154ad3b8aa4c992369dcf6?pvs=4)