### PR TITLE
[SAMBAD-305] 모임명 조회 API를 통해 모임 가입 여부 판별 가능하도록 수정

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/application/MeetingService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/application/MeetingService.java
@@ -1,6 +1,7 @@
 package org.depromeet.sambad.moring.meeting.meeting.application;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.depromeet.sambad.moring.meeting.meeting.domain.Meeting;
 import org.depromeet.sambad.moring.meeting.meeting.domain.MeetingCode;
@@ -13,9 +14,6 @@ import org.depromeet.sambad.moring.meeting.meeting.presentation.response.Meeting
 import org.depromeet.sambad.moring.meeting.member.application.MeetingMemberRepository;
 import org.depromeet.sambad.moring.meeting.member.domain.MeetingMember;
 import org.depromeet.sambad.moring.meeting.member.domain.MeetingMemberValidator;
-import org.depromeet.sambad.moring.user.domain.User;
-import org.depromeet.sambad.moring.user.domain.UserRepository;
-import org.depromeet.sambad.moring.user.presentation.exception.NotFoundUserException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,7 +24,6 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class MeetingService {
 
-	private final UserRepository userRepository;
 	private final MeetingRepository meetingRepository;
 	private final MeetingMemberRepository meetingMemberRepository;
 	private final MeetingTypeRepository meetingTypeRepository;
@@ -57,11 +54,14 @@ public class MeetingService {
 		return MeetingResponse.of(meetings, MeetingMember.getLastMeetingId(membersOfUser));
 	}
 
-	public MeetingNameResponse getMeetingNameByCode(String code) {
+	public MeetingNameResponse getMeetingNameByCode(Long userId, String code) {
 		Meeting meeting = meetingRepository.findByCode(MeetingCode.from(code))
 			.orElseThrow(MeetingNotFoundException::new);
 
-		return MeetingNameResponse.from(meeting);
+		Optional<MeetingMember> meetingMemberOptional = meetingMemberRepository.findByUserIdAndMeetingId(
+			userId, meeting.getId());
+
+		return MeetingNameResponse.of(meeting, meetingMemberOptional.isPresent());
 	}
 
 	public Meeting getMeeting(Long meetingId) {

--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/MeetingController.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/MeetingController.java
@@ -59,8 +59,8 @@ public class MeetingController {
 		@ApiResponse(responseCode = "404", description = "MEETING_NOT_FOUND"),
 	})
 	@GetMapping("/name")
-	public ResponseEntity<MeetingNameResponse> getMeetingName(@RequestParam String code) {
-		MeetingNameResponse response = meetingService.getMeetingNameByCode(code);
+	public ResponseEntity<MeetingNameResponse> getMeetingName(@UserId Long userId, @RequestParam String code) {
+		MeetingNameResponse response = meetingService.getMeetingNameByCode(userId, code);
 
 		return ResponseEntity.ok(response);
 	}

--- a/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/response/MeetingNameResponse.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/meeting/presentation/response/MeetingNameResponse.java
@@ -8,9 +8,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record MeetingNameResponse(
 	@Schema(description = "모임명", example = "삼밧드의 모험", requiredMode = REQUIRED)
-	String name
+	String name,
+
+	@Schema(description = "모임 가입 여부", example = "true", requiredMode = REQUIRED)
+	boolean joined
 ) {
-	public static MeetingNameResponse from(Meeting meeting) {
-		return new MeetingNameResponse(meeting.getName());
+	public static MeetingNameResponse of(Meeting meeting, boolean joined) {
+		return new MeetingNameResponse(meeting.getName(), joined);
 	}
 }


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 📝 개요
- `MeetingNameResponse`에 `joined` 필드를 추가합니다.
  - 공유 링크를 통해 모임 가입 페이지 접속 시, 클라이언트에서 모임 가입 여부를 통해 리다이렉트 위치를 지정합니다.

## 🔗 ISSUE 링크
- resolved [SAMBAD-305]()