### PR TITLE
[SAMBAD-306] 모임 가입 시, 마지막 접속 모임 업데이트하도록 수정

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/member/application/MeetingMemberService.java
@@ -64,6 +64,8 @@ public class MeetingMemberService {
 
 		createMeetingQuestionIfFirstMeetingMember(meeting, meetingMember);
 
+		user.updateLastAccessedMeeting(meeting.getId());
+
 		return MeetingMemberPersistResponse.from(meetingMember);
 	}
 


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- 모임 가입 후 홈 화면에 접속했을 때, 가입한 모임으로 이동하도록 플로우를 유도하기 위함입니다.


## 🔗 ISSUE 링크
- resolved [SAMBAD-306](https://www.notion.so/depromeet/ID-fbd5713bea154ad3b8aa4c992369dcf6?pvs=4)