### PR TITLE
[SAMBAD-309]- 손흔들기 수락 거절 시 이벤트 inactive

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/handwaving/application/HandWavingService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/handwaving/application/HandWavingService.java
@@ -56,6 +56,7 @@ public class HandWavingService {
 		HandWaving handWaving = getHandWavingById(handWavingId);
 		handWaving.validateIsReceiver(userId);
 		handWaving.accept();
+		eventService.inactivateLastEventByType(userId, meetingId, HAND_WAVING_REQUESTED);
 	}
 
 	@Transactional
@@ -64,6 +65,7 @@ public class HandWavingService {
 		HandWaving handWaving = getHandWavingById(handWavingId);
 		handWaving.validateIsReceiver(userId);
 		handWaving.reject();
+		eventService.inactivateLastEventByType(userId, meetingId, HAND_WAVING_REQUESTED);
 	}
 
 	public List<HandWavingSummary> getHandWavingSummariesBy(List<Event> events) {


### PR DESCRIPTION
### 📍 [SAMBAD-이슈번호] PR 제목


## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
-  손흔들기 수락 거절 시 이벤트 inactive

  ```java
    @Transactional
	public void acceptHandWaving(Long userId, Long meetingId, Long handWavingId) {
		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
		HandWaving handWaving = getHandWavingById(handWavingId);
		handWaving.validateIsReceiver(userId);
		handWaving.accept();
		eventService.inactivateLastEventByType(userId, meetingId, HAND_WAVING_REQUESTED);
	}
  ```


## 🔗 ISSUE 링크
- resolved [SAMBAD-이슈번호]()