### PR TITLE
[SAMBAD-309]-손흔들기 수락 거절 시 event 비활성화

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/handwaving/application/HandWavingService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/handwaving/application/HandWavingService.java
@@ -56,7 +56,7 @@ public class HandWavingService {
 		HandWaving handWaving = getHandWavingById(handWavingId);
 		handWaving.validateIsReceiver(userId);
 		handWaving.accept();
-		eventService.inactivate(handWaving.getEventId());
+		inactiveHandWavingEvent(handWaving);
 	}
 
 	@Transactional
@@ -65,7 +65,7 @@ public class HandWavingService {
 		HandWaving handWaving = getHandWavingById(handWavingId);
 		handWaving.validateIsReceiver(userId);
 		handWaving.reject();
-		eventService.inactivate(handWaving.getEventId());
+		inactiveHandWavingEvent(handWaving);
 	}
 
 	public List<HandWavingSummary> getHandWavingSummariesBy(List<Event> events) {
@@ -101,5 +101,12 @@ public class HandWavingService {
 		Long meetingId = receiver.getMeeting().getId();
 
 		eventService.publishHandWavingEvent(userId, meetingId, HAND_WAVING_REQUESTED, contentsMap, handWaving);
+	}
+
+	private void inactiveHandWavingEvent(HandWaving handWaving) {
+		Long eventId = handWaving.getEventId();
+		if (eventId != null) {
+			eventService.inactivate(eventId);
+		}
 	}
 }

--- a/src/main/java/org/depromeet/sambad/moring/meeting/handwaving/application/HandWavingService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/handwaving/application/HandWavingService.java
@@ -56,7 +56,7 @@ public class HandWavingService {
 		HandWaving handWaving = getHandWavingById(handWavingId);
 		handWaving.validateIsReceiver(userId);
 		handWaving.accept();
-		eventService.inactivateLastEventByType(userId, meetingId, HAND_WAVING_REQUESTED);
+		eventService.inactivate(handWaving.getEventId());
 	}
 
 	@Transactional
@@ -65,7 +65,7 @@ public class HandWavingService {
 		HandWaving handWaving = getHandWavingById(handWavingId);
 		handWaving.validateIsReceiver(userId);
 		handWaving.reject();
-		eventService.inactivateLastEventByType(userId, meetingId, HAND_WAVING_REQUESTED);
+		eventService.inactivate(handWaving.getEventId());
 	}
 
 	public List<HandWavingSummary> getHandWavingSummariesBy(List<Event> events) {

--- a/src/main/java/org/depromeet/sambad/moring/meeting/handwaving/application/HandWavingService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/handwaving/application/HandWavingService.java
@@ -56,6 +56,7 @@ public class HandWavingService {
 		HandWaving handWaving = getHandWavingById(handWavingId);
 		handWaving.validateIsReceiver(userId);
 		handWaving.accept();
+		eventService.inactivateLastEventByType(userId, meetingId, HAND_WAVING_REQUESTED);
 	}
 
 	@Transactional
@@ -64,6 +65,7 @@ public class HandWavingService {
 		HandWaving handWaving = getHandWavingById(handWavingId);
 		handWaving.validateIsReceiver(userId);
 		handWaving.reject();
+		eventService.inactivateLastEventByType(userId, meetingId, HAND_WAVING_REQUESTED);
 	}
 
 	public List<HandWavingSummary> getHandWavingSummariesBy(List<Event> events) {


### PR DESCRIPTION
### 📍 [SAMBAD-309]-손흔들기 수락 거절 시 event 비활성화

## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- 손흔들기 수락 거절 시 event 비활성화
- 
  ```java
    @Transactional
	public void acceptHandWaving(Long userId, Long meetingId, Long handWavingId) {
		meetingMemberValidator.validateUserIsMemberOfMeeting(userId, meetingId);
		HandWaving handWaving = getHandWavingById(handWavingId);
		handWaving.validateIsReceiver(userId);
		handWaving.accept();
		eventService.inactivate(handWaving.getEventId());
	}
  ```

## 💡 코드 리뷰 시 참고 사항
- 위 방법으로 할 경우 event 못찾으면 예외를 던집니다. 괜찮을까요?

## 🔗 ISSUE 링크
- resolved [SAMBAD-이슈번호]()