### PR TITLE
[SAMBAD-310]-손흔들기 accept 했을 때 프로필에서 NOT_REQUESTED로 뜨는 이슈 픽스

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/handwaving/application/HandWavingService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/handwaving/application/HandWavingService.java
@@ -45,8 +45,9 @@ public class HandWavingService {
 
 	public HandWavingStatusResponse getHandWavingStatus(Long userId, Long meetingId, Long receiverMemberId) {
 		MeetingMember sender = meetingMemberService.getByUserIdAndMeetingId(userId, meetingId);
-		Optional<HandWaving> handWaving = getHandWavingBySenderIdAndReceiverId(sender.getId(), receiverMemberId);
-		return handWaving.map(waving -> HandWavingStatusResponse.of(waving.getId(), waving.getStatus()))
+		Optional<HandWaving> handWaving = getHandWavingBySenderIdAndReceiverId(sender.getId(), receiverMemberId)
+			.or(() -> getHandWavingBySenderIdAndReceiverId(receiverMemberId, sender.getId()));
+		return handWaving.map(waving -> HandWavingStatusResponse.of(waving.getStatus()))
 			.orElseGet(() -> HandWavingStatusResponse.of(NOT_REQUESTED));
 	}
 


### PR DESCRIPTION
### 📍 [SAMBAD-310]-손흔들기 accept 했을 때 프로필에서 NOT_REQUESTED로 뜨는 이슈 픽스


## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- 손흔들기 accept 했을 때 프로필에서 NOT_REQUESTED로 뜨는 이슈 픽스
- sender receiver 바꿔서 한번 더 조회하고 둘다 empty면 NOT_REQUESTED 반환하게 함
  ```java
    public HandWavingStatusResponse getHandWavingStatus(Long userId, Long meetingId, Long receiverMemberId) {
		MeetingMember sender = meetingMemberService.getByUserIdAndMeetingId(userId, meetingId);
		Optional<HandWaving> handWaving = getHandWavingBySenderIdAndReceiverId(sender.getId(), receiverMemberId)
			.or(() -> getHandWavingBySenderIdAndReceiverId(receiverMemberId, sender.getId()));
		return handWaving.map(waving -> HandWavingStatusResponse.of(waving.getStatus()))
			.orElseGet(() -> HandWavingStatusResponse.of(NOT_REQUESTED));
	}
  ```


## 🔗 ISSUE 링크
- resolved [SAMBAD-이슈번호]()