### PR TITLE
[SAMBAD-311]- 손흔들기 상태 API에서 handwaving ID가 null이 되는 이슈 픽스

### DIFF
--- a/src/main/java/org/depromeet/sambad/moring/meeting/handwaving/application/HandWavingService.java
+++ b/src/main/java/org/depromeet/sambad/moring/meeting/handwaving/application/HandWavingService.java
@@ -47,7 +47,7 @@ public class HandWavingService {
 		MeetingMember sender = meetingMemberService.getByUserIdAndMeetingId(userId, meetingId);
 		Optional<HandWaving> handWaving = getHandWavingBySenderIdAndReceiverId(sender.getId(), receiverMemberId)
 			.or(() -> getHandWavingBySenderIdAndReceiverId(receiverMemberId, sender.getId()));
-		return handWaving.map(waving -> HandWavingStatusResponse.of(waving.getStatus()))
+		return handWaving.map(waving -> HandWavingStatusResponse.of(waving.getId(), waving.getStatus()))
 			.orElseGet(() -> HandWavingStatusResponse.of(NOT_REQUESTED));
 	}
 


### PR DESCRIPTION
### 📍 [SAMBAD-311]- 손흔들기 상태 API에서 handwaving ID가 null이 되는 이슈 픽스


## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- of를 잘못써서 id가 null로 들어갔습니다.
- 머지 후 재배포 하겠습니다


## 🔗 ISSUE 링크
- resolved [SAMBAD-이슈번호]()