### PR TITLE
[SAMBAD-312] 토큰 검증용 API 추가

### DIFF
--- a/moring-api/src/main/java/org/depromeet/sambad/moring/api/user/UserController.java
+++ b/moring-api/src/main/java/org/depromeet/sambad/moring/api/user/UserController.java
@@ -37,6 +37,14 @@ public class UserController {
 		return ResponseEntity.ok(response);
 	}
 
+	@Operation(summary = "토큰 유효성 조회", description = "오직 토큰의 유효성을 검증하기 위한 validation API 입니다.")
+	@ApiResponse(responseCode = "202", description = "성공")
+	@ApiResponse(responseCode = "401", description = "AUTHENTICATION_REQUIRED")
+	@GetMapping("/validate-token")
+	public ResponseEntity<Void> validateToken() {
+		return ResponseEntity.accepted().build();
+	}
+
 	@Operation(
 		summary = "온보딩 완료",
 		description = "온보딩을 완료함으로써, 더 이상 온보딩 페이지로 이동하지 않도록 수정합니다."

--- a/moring-infra/src/main/java/org/depromeet/sambad/moring/infra/config/JpaConfig.java
+++ b/moring-infra/src/main/java/org/depromeet/sambad/moring/infra/config/JpaConfig.java
@@ -9,8 +9,8 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import jakarta.persistence.EntityManager;
 
-@EntityScan(basePackages = "org.depromeet.sambad.moring.domain")
-@EnableJpaRepositories(basePackages = "org.depromeet.sambad.moring.domain")
+@EntityScan(basePackages = "org.depromeet.sambad.moring")
+@EnableJpaRepositories(basePackages = "org.depromeet.sambad.moring")
 public class JpaConfig implements MoringConfig {
 
 	private final EntityManager entityManager;


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 📝 개요
- 클라이언트의 미들웨어에서 토큰 검증용 API를 활용해야 할 요구사항이 있습니다.
  - 페이지 진입 전 토큰의 유효성을 검증하고, 유효하지 않다면 `/auth`로 리다이렉트합니다.

## 🔗 ISSUE 링크
- resolved [SAMBAD-312](https://www.notion.so/depromeet/API-509872b0e83c41ae85b70b5875b3de7a?pvs=4)