### PR TITLE
[SAMBAD-327] 모임원 목록 조회 응답에 본인 여부, 손 흔들기 상태 필드 추가

### DIFF
--- a/moring-api/src/main/java/org/depromeet/sambad/moring/api/meeting/member/MeetingMemberController.java
+++ b/moring-api/src/main/java/org/depromeet/sambad/moring/api/meeting/member/MeetingMemberController.java
@@ -100,8 +100,7 @@ public class MeetingMemberController {
 		return ResponseEntity.ok(response);
 	}
 
-	@Operation(summary = "모임원 목록 조회", description = "- 특정 모임의 모임원 목록을 조회합니다.\n"
-		+ "- 자기 자신은 목록에서 제외합니다.")
+	@Operation(summary = "모임원 목록 조회", description = "- 특정 모임의 모임원 목록을 조회합니다.")
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "모임원 목록 조회 성공"),
 		@ApiResponse(responseCode = "403", description = "USER_NOT_MEMBER_OF_MEETING")

--- a/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/common/utils/UserIdResolver.java
+++ b/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/common/utils/UserIdResolver.java
@@ -1,0 +1,16 @@
+package org.depromeet.sambad.moring.domain.common.utils;
+
+import java.util.Optional;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class UserIdResolver {
+
+	public static Long resolveRequestedUserId() {
+		return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+			.map(Authentication::getName)
+			.map(Long::valueOf)
+			.orElse(null);
+	}
+}

--- a/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/meeting/handwaving/application/HandWavingRepository.java
+++ b/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/meeting/handwaving/application/HandWavingRepository.java
@@ -3,8 +3,8 @@ package org.depromeet.sambad.moring.domain.meeting.handwaving.application;
 import java.util.List;
 import java.util.Optional;
 
+import org.depromeet.sambad.moring.domain.meeting.handwaving.domain.HandWavedMemberDto;
 import org.depromeet.sambad.moring.domain.meeting.handwaving.domain.HandWaving;
-import org.depromeet.sambad.moring.domain.meeting.member.domain.MeetingMember;
 
 public interface HandWavingRepository {
 
@@ -14,7 +14,7 @@ public interface HandWavingRepository {
 
 	Optional<HandWaving> findFirstBySenderIdAndReceiverIdOrderByIdDesc(Long senderMemberId, Long receiverMemberId);
 
-	List<MeetingMember> findHandWavedMembersByMeetingMemberId(Long meetingMemberId);
+	List<HandWavedMemberDto> findHandWavedMembersByMeetingMemberId(Long meetingMemberId);
 
 	List<HandWaving> findAllByEventIdIn(List<Long> eventIds);
 }

--- a/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/meeting/handwaving/domain/HandWavedMemberDto.java
+++ b/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/meeting/handwaving/domain/HandWavedMemberDto.java
@@ -1,0 +1,16 @@
+package org.depromeet.sambad.moring.domain.meeting.handwaving.domain;
+
+import org.depromeet.sambad.moring.domain.meeting.member.domain.MeetingMember;
+
+public record HandWavedMemberDto(
+	MeetingMember handWavedMember,
+	HandWaving handWaving
+) {
+	public Long getMemberId() {
+		return handWavedMember.getId();
+	}
+
+	public HandWavingStatus getStatus() {
+		return handWaving.getStatus();
+	}
+}

--- a/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/meeting/member/application/MeetingMemberRepository.java
+++ b/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/meeting/member/application/MeetingMemberRepository.java
@@ -14,7 +14,8 @@ public interface MeetingMemberRepository {
 
 	Optional<MeetingMember> findByUserIdAndMeetingId(Long userId, Long meetingId);
 
-	List<MeetingMember> findByMeetingIdAndMeetingMemberIdNotOrderByName(Long meetingId, Long loginMeetingMemberId);
+	List<MeetingMember> findByMeetingIdAndMeetingMemberIdNotInOrderByName(
+		Long meetingId, List<Long> excludeMemberIds);
 
 	List<MeetingMember> findNextTargetsByMeeting(Long meetingId, Long loginMeetingMemberId,
 		List<Long> excludeMemberIds);

--- a/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/meeting/member/domain/MeetingMember.java
+++ b/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/meeting/member/domain/MeetingMember.java
@@ -1,6 +1,7 @@
 package org.depromeet.sambad.moring.domain.meeting.member.domain;
 
 import static jakarta.persistence.EnumType.*;
+import static org.depromeet.sambad.moring.domain.common.utils.UserIdResolver.*;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -141,6 +142,10 @@ public class MeetingMember extends BaseTimeEntity implements Comparable<MeetingM
 
 	public boolean isOwner() {
 		return role.equals(MeetingMemberRole.OWNER);
+	}
+
+	public boolean isMe() {
+		return Objects.equals(this.user.getId(), resolveRequestedUserId());
 	}
 
 	@Override

--- a/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/meeting/member/infrastructure/MeetingMemberJpaRepository.java
+++ b/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/meeting/member/infrastructure/MeetingMemberJpaRepository.java
@@ -10,7 +10,9 @@ public interface MeetingMemberJpaRepository extends JpaRepository<MeetingMember,
 
 	List<MeetingMember> findByUserId(Long userId);
 
-	List<MeetingMember> findByMeetingIdAndIdNotOrderByName(Long meetingId, Long meetingMemberId);
+	List<MeetingMember> findByMeetingIdAndIdNotInOrderByName(Long meetingId, List<Long> excludeMemberIds);
+
+	List<MeetingMember> findByMeetingIdOrderByName(Long meetingId);
 
 	Optional<MeetingMember> findByUserIdAndMeetingId(Long userId, Long meetingId);
 }

--- a/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/meeting/member/infrastructure/MeetingMemberRepositoryImpl.java
+++ b/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/meeting/member/infrastructure/MeetingMemberRepositoryImpl.java
@@ -58,10 +58,14 @@ public class MeetingMemberRepositoryImpl implements MeetingMemberRepository {
 		return meetingMemberQueryRepository.isOwnerExceedingMaxMeetings(meetingId, maxHostMeetings);
 	}
 
-	public List<MeetingMember> findByMeetingIdAndMeetingMemberIdNotOrderByName(Long meetingId,
-		Long loginMeetingMemberId) {
-		return meetingMemberJpaRepository.findByMeetingIdAndIdNotOrderByName(meetingId,
-			loginMeetingMemberId);
+	@Override
+	public List<MeetingMember> findByMeetingIdAndMeetingMemberIdNotInOrderByName(
+		Long meetingId, List<Long> excludeMemberIds
+	) {
+		if (excludeMemberIds.isEmpty()) {
+			return meetingMemberJpaRepository.findByMeetingIdOrderByName(meetingId);
+		}
+		return meetingMemberJpaRepository.findByMeetingIdAndIdNotInOrderByName(meetingId, excludeMemberIds);
 	}
 
 	@Override

--- a/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/meeting/member/presentation/request/MeetingMemberPersistRequest.java
+++ b/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/meeting/member/presentation/request/MeetingMemberPersistRequest.java
@@ -43,7 +43,6 @@ public record MeetingMemberPersistRequest(
 	String location,
 
 	@Schema(description = "모임원 취미 ID 리스트", example = "[1, 2, 3]", requiredMode = NOT_REQUIRED)
-	@Size(max = 3)
 	List<Long> hobbyIds,
 
 	@Schema(description = "모임원 MBTI", example = "ISFP", requiredMode = NOT_REQUIRED)

--- a/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/meeting/member/presentation/response/MeetingMemberListResponse.java
+++ b/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/meeting/member/presentation/response/MeetingMemberListResponse.java
@@ -2,8 +2,10 @@ package org.depromeet.sambad.moring.domain.meeting.member.presentation.response;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import org.depromeet.sambad.moring.domain.meeting.handwaving.domain.HandWavedMemberDto;
 import org.depromeet.sambad.moring.domain.meeting.member.domain.MeetingMember;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -11,18 +13,42 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record MeetingMemberListResponse(
 	@Schema(
 		description = "모임원 목록",
-		example = "[{\"meetingMemberId\":1,\"name\":\"이한음\",\"profileImageFileUrl\":\"https://example.com\",\"role\":\"OWNER\"}]",
 		requiredMode = REQUIRED
 	)
 	List<MeetingMemberListResponseDetail> contents
 ) {
 
-	public static MeetingMemberListResponse from(List<MeetingMember> members, List<MeetingMember> handWavedMembers) {
-		List<MeetingMemberListResponseDetail> memberResponses = members.stream()
+	public static MeetingMemberListResponse from(
+		MeetingMember me, List<MeetingMember> notHandWavedMembers, List<HandWavedMemberDto> handWavedMembers
+	) {
+		List<MeetingMember> sortedHandWavedMembers = handWavedMembers.stream()
+			.map(HandWavedMemberDto::handWavedMember)
 			.sorted()
+			.toList();
+
+		List<MeetingMember> sortedNotHandWavedMembers = notHandWavedMembers.stream()
+			.sorted()
+			.toList();
+
+		List<MeetingMember> mergedMembers = mergeMeetingMembers(me, sortedHandWavedMembers, sortedNotHandWavedMembers);
+
+		List<MeetingMemberListResponseDetail> memberResponses = mergedMembers.stream()
 			.map(member -> MeetingMemberListResponseDetail.from(member, handWavedMembers))
 			.toList();
 
 		return new MeetingMemberListResponse(memberResponses);
+	}
+
+	private static List<MeetingMember> mergeMeetingMembers(
+		MeetingMember me, List<MeetingMember> sortedHandWavedMember, List<MeetingMember> sortedNotHandWavedMembers
+	) {
+		List<MeetingMember> mergedMembers = new ArrayList<>();
+
+		// 다음과 같은 순서대로 모임원 목록을 구성
+		mergedMembers.add(me);
+		mergedMembers.addAll(sortedHandWavedMember);
+		mergedMembers.addAll(sortedNotHandWavedMembers);
+
+		return mergedMembers;
 	}
 }

--- a/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/meeting/question/application/MeetingQuestionService.java
+++ b/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/meeting/question/application/MeetingQuestionService.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import org.depromeet.sambad.moring.domain.event.application.EventService;
 import org.depromeet.sambad.moring.domain.event.domain.EventType;
 import org.depromeet.sambad.moring.domain.meeting.handwaving.application.HandWavingRepository;
+import org.depromeet.sambad.moring.domain.meeting.handwaving.domain.HandWavedMemberDto;
 import org.depromeet.sambad.moring.domain.meeting.meeting.domain.Meeting;
 import org.depromeet.sambad.moring.domain.meeting.member.application.MeetingMemberService;
 import org.depromeet.sambad.moring.domain.meeting.member.domain.MeetingMember;
@@ -152,9 +153,10 @@ public class MeetingQuestionService {
 			meetingQuestion.getId());
 		MeetingMember me = meetingMemberService.getByUserIdAndMeetingId(userId, meetingId);
 
-		List<MeetingMember> handWavedMembers = handWavingRepository.findHandWavedMembersByMeetingMemberId(me.getId());
+		List<HandWavedMemberDto> handWavedMembers = handWavingRepository.findHandWavedMembersByMeetingMemberId(
+			me.getId());
 
-		return MeetingMemberListResponse.from(members, handWavedMembers);
+		return MeetingMemberListResponse.from(me, members, handWavedMembers);
 	}
 
 	private CurrentMeetingQuestionResponse getCurrentMeetingQuestionResponse(


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- 모임원 목록 조회 순서를 수정합니다.
  - 나, 손 흔들기 한 모임원, 손 흔들기 대기 중인 모임원, 모임장, 가나다 순입니다.
  - 자세한 내용은 디자인 정의서 변경 내용을 참고 부탁드립니다.
- `isMe`, `handWavingStatus` 필드를 추가합니다.
  - 본인은 `나` 로 표시되어야 하며, 손 흔들기 대기 중인 모임원은 손 흔들기 마크를 회색으로 표시해줘야 할 요구사항이 생겼습니다.

## 🔗 ISSUE 링크
- resolved [SAMBAD-327](https://www.notion.so/depromeet/c323731e4e434468b39d413f779ff16f?pvs=4)