### PR TITLE
[SAMBAD-333] 모임원 목록 조회 시 손 흔들어 인사하기 수락, 요청 순으로 표시되도록 수정

### DIFF
--- a/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/meeting/handwaving/domain/HandWavedMemberDto.java
+++ b/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/meeting/handwaving/domain/HandWavedMemberDto.java
@@ -1,5 +1,7 @@
 package org.depromeet.sambad.moring.domain.meeting.handwaving.domain;
 
+import java.util.Objects;
+
 import org.depromeet.sambad.moring.domain.meeting.member.domain.MeetingMember;
 
 public record HandWavedMemberDto(
@@ -12,5 +14,13 @@ public record HandWavedMemberDto(
 
 	public HandWavingStatus getStatus() {
 		return handWaving.getStatus();
+	}
+
+	public boolean isRequested() {
+		return Objects.equals(handWaving.getStatus(), HandWavingStatus.REQUESTED);
+	}
+
+	public boolean isAccepted() {
+		return Objects.equals(handWaving.getStatus(), HandWavingStatus.ACCEPTED);
 	}
 }

--- a/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/meeting/handwaving/infrastructure/HandWavingRepositoryImpl.java
+++ b/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/meeting/handwaving/infrastructure/HandWavingRepositoryImpl.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import org.depromeet.sambad.moring.domain.meeting.handwaving.application.HandWavingRepository;
 import org.depromeet.sambad.moring.domain.meeting.handwaving.domain.HandWavedMemberDto;
 import org.depromeet.sambad.moring.domain.meeting.handwaving.domain.HandWaving;
+import org.depromeet.sambad.moring.domain.meeting.handwaving.domain.HandWavingStatus;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.Tuple;
@@ -49,7 +50,8 @@ public class HandWavingRepositoryImpl implements HandWavingRepository {
 			.where(
 				handWaving.receiver.id.eq(meetingMemberId)
 					.or(handWaving.sender.id.eq(meetingMemberId)),
-				meetingMember.id.ne(meetingMemberId)
+				meetingMember.id.ne(meetingMemberId),
+				handWaving.status.in(HandWavingStatus.ACCEPTED, HandWavingStatus.REQUESTED)
 			)
 			.fetch();
 


### PR DESCRIPTION
## ✔️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정


## 📝 개요
- 모임원 목록 조회 시, 손 흔들어 인사하기 한 유저가 구분 없이 섞여서 표시되는 이슈가 있었습니다.
- 순서대로 표시되도록 수정합니다.

## 🔗 ISSUE 링크
- resolved [SAMBAD-333](https://www.notion.so/depromeet/f012792bdc234ae0b84c7e4197a22a94?pvs=4)