### PR TITLE
 [SAMBAD-335] 테스트 설정 및 MeetingQuestion 도메인 테스트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ subprojects {
 
 		testImplementation 'org.springframework.boot:spring-boot-starter-test'
 		testImplementation 'org.springframework.security:spring-security-test'
+		testImplementation 'org.assertj:assertj-core:3.27.3'
 		testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 		implementation 'com.amazonaws:aws-java-sdk-s3:1.11.238'

--- a/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/auth/application/dto/AuthAttributes.java
+++ b/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/auth/application/dto/AuthAttributes.java
@@ -22,7 +22,9 @@ public interface AuthAttributes {
 		if (LoginProvider.kakao.isProviderOf(providerId)) {
 			return KakaoAuthAttributes.of(attributes);
 		}
-
+		if (LoginProvider.test.isProviderOf(providerId)) {
+			return MockAuthAttributes.of();
+		}
 		throw new IllegalArgumentException("Unsupported id: " + providerId);
 	}
 }

--- a/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/auth/application/dto/MockAuthAttributes.java
+++ b/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/auth/application/dto/MockAuthAttributes.java
@@ -1,0 +1,39 @@
+package org.depromeet.sambad.moring.domain.auth.application.dto;
+
+import org.depromeet.sambad.moring.domain.user.domain.LoginProvider;
+
+public class MockAuthAttributes implements AuthAttributes {
+	@Override
+	public String getExternalId() {
+		return "test";
+	}
+
+	@Override
+	public String getEmail() {
+		return "test@kakao.com";
+	}
+
+	@Override
+	public String getName() {
+		return "test";
+	}
+
+	@Override
+	public String getProfileImageUrl() {
+		return null;
+	}
+
+	@Override
+	public LoginProvider getProvider() {
+		return LoginProvider.kakao;
+	}
+
+	@Override
+	public boolean hasDefaultProfileImage() {
+		return false;
+	}
+
+	public static MockAuthAttributes of() {
+		return new MockAuthAttributes();
+	}
+}

--- a/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/meeting/question/application/MeetingQuestionService.java
+++ b/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/meeting/question/application/MeetingQuestionService.java
@@ -1,6 +1,5 @@
 package org.depromeet.sambad.moring.domain.meeting.question.application;
 
-import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -48,8 +47,6 @@ public class MeetingQuestionService {
 
 	private final MeetingMemberValidator meetingMemberValidator;
 
-	private final Clock clock;
-
 	@Transactional
 	public CurrentMeetingQuestionResponse save(Long userId, Long meetingId, MeetingQuestionRequest request) {
 		MeetingMember loginMember = meetingMemberService.getByUserIdAndMeetingId(userId, meetingId);
@@ -85,7 +82,7 @@ public class MeetingQuestionService {
 	@Transactional
 	public MeetingQuestion createActiveQuestion(Meeting meeting, MeetingMember targetMember, Question activeQuestion) {
 		MeetingQuestion activeMeetingQuestion = MeetingQuestion.createActiveMeetingQuestion(meeting, targetMember,
-			activeQuestion, LocalDateTime.now(clock), meeting.getTotalMemberCount());
+			activeQuestion, LocalDateTime.now(), meeting.getTotalMemberCount());
 		return meetingQuestionRepository.save(activeMeetingQuestion);
 	}
 

--- a/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/user/domain/LoginProvider.java
+++ b/moring-domain/src/main/java/org/depromeet/sambad/moring/domain/user/domain/LoginProvider.java
@@ -3,7 +3,7 @@ package org.depromeet.sambad.moring.domain.user.domain;
 import java.util.Objects;
 
 public enum LoginProvider {
-	kakao;
+	kakao, test;
 
 	public boolean isProviderOf(String providerId) {
 		return Objects.equals(this.name(), providerId);

--- a/moring-domain/src/test/java/org/depromeet/sambad/moring/domain/meeting/question/TestApplication.java
+++ b/moring-domain/src/test/java/org/depromeet/sambad/moring/domain/meeting/question/TestApplication.java
@@ -1,0 +1,14 @@
+package org.depromeet.sambad.moring.domain.meeting.question;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootApplication
+public class TestApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(TestApplication.class, args);
+	}
+}

--- a/moring-domain/src/test/java/org/depromeet/sambad/moring/domain/meeting/question/domain/MeetingQuestionTest.java
+++ b/moring-domain/src/test/java/org/depromeet/sambad/moring/domain/meeting/question/domain/MeetingQuestionTest.java
@@ -2,6 +2,7 @@ package org.depromeet.sambad.moring.domain.meeting.question.domain;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.SoftAssertions.*;
+import static org.depromeet.sambad.moring.domain.meeting.question.domain.MeetingQuestionStatus.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -9,6 +10,7 @@ import java.util.List;
 
 import org.depromeet.sambad.moring.domain.auth.application.dto.AuthAttributes;
 import org.depromeet.sambad.moring.domain.common.domain.Gender;
+import org.depromeet.sambad.moring.domain.file.domain.FileEntity;
 import org.depromeet.sambad.moring.domain.meeting.meeting.domain.Meeting;
 import org.depromeet.sambad.moring.domain.meeting.meeting.domain.MeetingCode;
 import org.depromeet.sambad.moring.domain.meeting.meeting.presentation.request.MeetingPersistRequest;
@@ -16,6 +18,8 @@ import org.depromeet.sambad.moring.domain.meeting.member.domain.MBTI;
 import org.depromeet.sambad.moring.domain.meeting.member.domain.MeetingMember;
 import org.depromeet.sambad.moring.domain.meeting.member.domain.MeetingMemberRole;
 import org.depromeet.sambad.moring.domain.meeting.member.presentation.request.MeetingMemberPersistRequest;
+import org.depromeet.sambad.moring.domain.question.domain.Question;
+import org.depromeet.sambad.moring.domain.question.domain.QuestionType;
 import org.depromeet.sambad.moring.domain.user.domain.LoginProvider;
 import org.depromeet.sambad.moring.domain.user.domain.User;
 import org.junit.jupiter.api.Test;
@@ -25,7 +29,7 @@ import org.springframework.test.context.ActiveProfiles;
 class MeetingQuestionTest {
 
 	@Test
-	void 다음_모임_질문을_생성할_수_있다() {
+	void 다음_턴의_모임_질문을_생성할_수_있다() {
 		// given
 		Meeting meeting = createMeeting();
 		MeetingMember meetingMember = createMeetingMember(meeting);
@@ -39,8 +43,29 @@ class MeetingQuestionTest {
 			assertThat(nextMeetingQuestion.getMeeting()).isNotNull();
 			assertThat(nextMeetingQuestion.getQuestion()).isNull();
 			assertThat(nextMeetingQuestion.getTargetMember()).isNotNull();
-			assertThat(nextMeetingQuestion.getStatus()).isEqualTo(MeetingQuestionStatus.NOT_STARTED);
+			assertThat(nextMeetingQuestion.getStatus()).isEqualTo(NOT_STARTED);
 			assertThat(nextMeetingQuestion.getTotalMemberCount()).isGreaterThan(0);
+		});
+	}
+
+	@Test
+	void 현재_턴의_모임_질문을_생성할_수_있다() {
+		// given
+		Meeting meeting = createMeeting();
+		MeetingMember meetingMember = createMeetingMember(meeting);
+		Question question = createQuestion();
+
+		// when
+		MeetingQuestion activeMeetingQuestion = MeetingQuestion.createActiveMeetingQuestion(meeting, meetingMember,
+			question, LocalDateTime.now(), 1);
+
+		// then
+		assertSoftly(softly -> {
+			assertThat(activeMeetingQuestion.getMeeting()).isNotNull();
+			assertThat(activeMeetingQuestion.getQuestion()).isNotNull();
+			assertThat(activeMeetingQuestion.getTargetMember()).isNotNull();
+			assertThat(activeMeetingQuestion.getStatus()).isEqualTo(ACTIVE);
+			assertThat(activeMeetingQuestion.getTotalMemberCount()).isGreaterThan(0);
 		});
 	}
 
@@ -57,5 +82,13 @@ class MeetingQuestionTest {
 			"개발자", "인천", List.of(1L), MBTI.ENFJ, "반갑다 친구들아");
 
 		return MeetingMember.createMemberWith(meeting, user, meetingMemberPersistRequest);
+	}
+
+	private Question createQuestion() {
+		return new Question("테스트",
+			"제목",
+			FileEntity.of("profile1.png", "images/profile1.png"),
+			QuestionType.MULTIPLE_DESCRIPTIVE_CHOICE,
+			List.of("답1", "답2"));
 	}
 }

--- a/moring-domain/src/test/java/org/depromeet/sambad/moring/domain/meeting/question/domain/MeetingQuestionTest.java
+++ b/moring-domain/src/test/java/org/depromeet/sambad/moring/domain/meeting/question/domain/MeetingQuestionTest.java
@@ -1,0 +1,61 @@
+package org.depromeet.sambad.moring.domain.meeting.question.domain;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.SoftAssertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.depromeet.sambad.moring.domain.auth.application.dto.AuthAttributes;
+import org.depromeet.sambad.moring.domain.common.domain.Gender;
+import org.depromeet.sambad.moring.domain.meeting.meeting.domain.Meeting;
+import org.depromeet.sambad.moring.domain.meeting.meeting.domain.MeetingCode;
+import org.depromeet.sambad.moring.domain.meeting.meeting.presentation.request.MeetingPersistRequest;
+import org.depromeet.sambad.moring.domain.meeting.member.domain.MBTI;
+import org.depromeet.sambad.moring.domain.meeting.member.domain.MeetingMember;
+import org.depromeet.sambad.moring.domain.meeting.member.domain.MeetingMemberRole;
+import org.depromeet.sambad.moring.domain.meeting.member.presentation.request.MeetingMemberPersistRequest;
+import org.depromeet.sambad.moring.domain.user.domain.LoginProvider;
+import org.depromeet.sambad.moring.domain.user.domain.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+class MeetingQuestionTest {
+
+	@Test
+	void 다음_모임_질문을_생성할_수_있다() {
+		// given
+		Meeting meeting = createMeeting();
+		MeetingMember meetingMember = createMeetingMember(meeting);
+
+		// when
+		MeetingQuestion nextMeetingQuestion = MeetingQuestion.createNextMeetingQuestion(meeting, meetingMember,
+			LocalDateTime.now(), 1);
+
+		// then
+		assertSoftly(softly -> {
+			assertThat(nextMeetingQuestion.getMeeting()).isNotNull();
+			assertThat(nextMeetingQuestion.getQuestion()).isNull();
+			assertThat(nextMeetingQuestion.getTargetMember()).isNotNull();
+			assertThat(nextMeetingQuestion.getStatus()).isEqualTo(MeetingQuestionStatus.NOT_STARTED);
+			assertThat(nextMeetingQuestion.getTotalMemberCount()).isGreaterThan(0);
+		});
+	}
+
+	private Meeting createMeeting() {
+		return Meeting.of(
+			new MeetingPersistRequest("나현이와아이들", List.of(1L)), MeetingCode.from("777777")
+		);
+	}
+
+	private MeetingMember createMeetingMember(Meeting meeting) {
+		User user = User.from(null, AuthAttributes.of(LoginProvider.test.name(), null));
+		MeetingMemberPersistRequest meetingMemberPersistRequest = new MeetingMemberPersistRequest(
+			MeetingMemberRole.MEMBER, "나현", Gender.FEMALE, LocalDate.of(1999, 7, 9),
+			"개발자", "인천", List.of(1L), MBTI.ENFJ, "반갑다 친구들아");
+
+		return MeetingMember.createMemberWith(meeting, user, meetingMemberPersistRequest);
+	}
+}

--- a/moring-domain/src/test/resources/application-test.yml
+++ b/moring-domain/src/test/resources/application-test.yml
@@ -1,0 +1,12 @@
+spring:
+  config:
+    activate:
+      on-profile: "test"
+
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=MYSQL
+
+  jpa:
+    properties:
+      hibernate:
+        default_batch_fetch_size: 1000


### PR DESCRIPTION
## ✏️ 변경 사항
### 테스트 설정 관련

[11a181d](https://github.com/depromeet/moring-server/commit/11a181d058a20bfa487813b134236d9ac618327e)
[a1ec400](https://github.com/depromeet/moring-server/commit/a1ec4008454f338ab615ca7c2eaafcc58342883b)
[cc2193](https://github.com/depromeet/moring-server/commit/cc2193c56ebcc2333de88173d6b40b705621b417)
- 테스트 관련 기능(assertSoftly) 사용을 위해 `assertj-core` 의존성 추가합니다. [참고](https://zzang9ha.tistory.com/418#google_vignette)
- 멀티모듈 구조로 바꾸면서 실제 실행 서버 모듈 외에는 Main 메소드가 존재하지 않습니다. 이러한 문제를 해결하기 위해 domain 모듈 내 Application 클래스를 추가하였습니다. [참고](https://medium.com/@jojiapp/springboot-multi-module%EC%97%90%EC%84%9C-springboottest-%EC%82%AC%EC%9A%A9-%EC%8B%9C-springbootconfiguration-%EB%AA%BB%EC%B0%BE%EC%9D%84-%EB%95%8C-with-c29cf0c81e55)

- MeetingQuestion 도메인 객체 생성에 대한 성공 테스트를 추가하였습니다. 추가 테스트는 프로덕션 코드 변경이 예상되어 PR 분리할 예정입니다. (안할지도~)

## 🔗 ISSUE 링크
- resolved [SAMBAD-335](https://www.notion.so/depromeet/MeetingQuestion-1a445b4338b3809aaa03c1de9a323e3c?pvs=4)